### PR TITLE
fix(core): add serialization default to `blobGasUsed` in `RpcReceiptTxInfo`

### DIFF
--- a/crates/networking/rpc/types/receipt.rs
+++ b/crates/networking/rpc/types/receipt.rs
@@ -155,7 +155,8 @@ pub struct RpcReceiptTxInfo {
     pub blob_gas_price: Option<u64>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        with = "serde_utils::u64::hex_str_opt"
+        with = "serde_utils::u64::hex_str_opt",
+        default = "Option::default"
     )]
     pub blob_gas_used: Option<u64>,
 }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
On L2, when trying to make an EIP1559 transaction, it fails because serde doesn't find `blobGasUsed` in the receipt.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
The `default` argument is provided to `serde()` macro on that field so it won't fail.

<!-- Link to issues: Resolves #111, Resolves #222 -->


