### PR TITLE
chore(l2): prevent Hive workflow to execute on L2-only changes

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -4,8 +4,10 @@ on:
   merge_group:
   push:
     branches: [main]
+    paths-ignore: ["crates/l2/**"]
   pull_request:
     branches: ["*"]
+    paths-ignore: ["crates/l2/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Hive tests takes too long and slows down the L2 CD.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
As changes L2-only files should not affect Hive results, we added `crates/l2/**` to `paths-ignore`

<!-- Link to issues: Resolves #111, Resolves #222 -->

