### PR TITLE
fix(l2): gracefully stop `ProofDataProvider`

### DIFF
--- a/crates/l2/utils/config/proof_data_provider.rs
+++ b/crates/l2/utils/config/proof_data_provider.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 
 use super::errors::ConfigError;
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct ProofDataProviderConfig {
     pub listen_ip: IpAddr,
     pub listen_port: u16,


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
When `Ctrl+C` is sent to the process, the `ProofDataProvider` listener is still opened waiting for new connections, causing the process to not finish.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Now the listener is launched in a new thread, and the previous thread have a signal handler that sends a message under a `mpsc` channel to the listener so it stops.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #809 

