### PR TITLE
feat(l1): add Assertoor support to localnet

### DIFF
--- a/crates/networking/p2p/net.rs
+++ b/crates/networking/p2p/net.rs
@@ -112,7 +112,7 @@ async fn discover_peers_server(
 
     loop {
         let (read, from) = udp_socket.recv_from(&mut buf).await.unwrap();
-        info!("Received {read} bytes from {from}");
+        debug!("Received {read} bytes from {from}");
 
         let packet = Packet::decode(&buf[..read]);
         if packet.is_err() {
@@ -122,7 +122,7 @@ async fn discover_peers_server(
         let packet = packet.unwrap();
 
         let msg = packet.get_message();
-        info!("Message: {:?} from {}", msg, packet.get_node_id());
+        debug!("Message: {:?} from {}", msg, packet.get_node_id());
 
         match msg {
             Message::Ping(msg) => {
@@ -729,9 +729,9 @@ async fn serve_requests(tcp_addr: SocketAddr, signer: SigningKey, storage: Store
         ping(&udp_socket, tcp_addr, udp_addr, &signer).await;
 
         let (read, from) = udp_socket.recv_from(&mut buf).await.unwrap();
-        info!("RLPx: Received {read} bytes from {from}");
+        debug!("RLPx: Received {read} bytes from {from}");
         let packet = Packet::decode(&buf[..read]).unwrap();
-        info!("RLPx: Message: {:?}", packet);
+        debug!("RLPx: Message: {:?}", packet);
 
         match packet.get_message() {
             Message::Pong(pong) => {

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -142,6 +142,7 @@ pub enum RpcNamespace {
     Eth,
     Admin,
     Debug,
+    Web3,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -168,6 +169,7 @@ impl RpcRequest {
                 "eth" => Ok(RpcNamespace::Eth),
                 "admin" => Ok(RpcNamespace::Admin),
                 "debug" => Ok(RpcNamespace::Debug),
+                "web3" => Ok(RpcNamespace::Web3),
                 _ => Err(RpcErr::MethodNotFound(self.method.clone())),
             }
         } else {

--- a/crates/networking/rpc/web3/mod.rs
+++ b/crates/networking/rpc/web3/mod.rs
@@ -1,0 +1,8 @@
+use ethereum_rust_storage::Store;
+use serde_json::Value;
+
+use crate::utils::{RpcErr, RpcRequest};
+
+pub fn client_version(_req: &RpcRequest, _store: Store) -> Result<Value, RpcErr> {
+    Ok(Value::String("ethereum_rust@0.1.0".to_owned()))
+}

--- a/test_data/network_params.yaml
+++ b/test_data/network_params.yaml
@@ -4,6 +4,12 @@ participants:
     count: 2
   - el_type: ethereumrust
     cl_type: lighthouse
-    vc_count: 0
-    validator_count: 0
     count: 1
+
+additional_services:
+  - assertoor
+  - dora
+
+assertoor_params:
+  run_stability_check: true
+  run_block_proposal_check: false


### PR DESCRIPTION
**Motivation**
Be able to run a suite of tests over a localnet as part of the CI or post merge

**Description**
Added assertoor to the localnet. To learn about assertoor, see: https://ethpandaops.io/posts/assertoor-introduction/

As part of this task, I had to add the `web3_clientVersion` RPC endpoint, which for now returns `ethereum_rust@0.1.0`. We can improve this later.


