### PR TITLE
fix(l2): remove duplicated `eth_gasPrice` client implementation

### DIFF
--- a/cmd/ethereum_rust_l2/src/commands/wallet.rs
+++ b/cmd/ethereum_rust_l2/src/commands/wallet.rs
@@ -148,7 +148,7 @@ impl Command {
                     value: amount,
                     chain_id: cfg.network.l1_chain_id,
                     nonce: eth_client.get_nonce(from).await?,
-                    max_fee_per_gas: eth_client.gas_price().await?.as_u64(),
+                    max_fee_per_gas: eth_client.get_gas_price().await?.as_u64(),
                     ..Default::default()
                 };
 

--- a/crates/l2/operator/l1_watcher.rs
+++ b/crates/l2/operator/l1_watcher.rs
@@ -130,7 +130,7 @@ impl L1Watcher {
                 .map_err(|e| L1WatcherError::FailedToRetrieveDepositorAccountInfo(e.to_string()))?
                 .map(|info| info.nonce)
                 .unwrap_or_default();
-            mint_transaction.max_fee_per_gas = self.eth_client.gas_price().await?.as_u64();
+            mint_transaction.max_fee_per_gas = self.eth_client.get_gas_price().await?.as_u64();
             // TODO(IMPORTANT): gas_limit should come in the log and must
             // not be calculated in here. The reason for this is that the
             // gas_limit for this transaction is payed by the caller in

--- a/crates/l2/operator/mod.rs
+++ b/crates/l2/operator/mod.rs
@@ -276,7 +276,7 @@ impl Operator {
             .await?
             .saturating_add(TX_GAS_COST);
 
-        tx.max_fee_per_gas = self.eth_client.get_gas_price().await?;
+        tx.max_fee_per_gas = self.eth_client.get_gas_price().await?.as_u64();
 
         tx.nonce = self.eth_client.get_nonce(self.l1_address).await?;
 

--- a/crates/l2/utils/eth_client/errors.rs
+++ b/crates/l2/utils/eth_client/errors.rs
@@ -18,8 +18,6 @@ pub enum EthClientError {
     GetBlockNumberError(#[from] GetBlockNumberError),
     #[error("eth_getLogs request error: {0}")]
     GetLogsError(#[from] GetLogsError),
-    #[error("eth_gasPrice request error: {0}")]
-    GasPriceError(#[from] GasPriceError),
     #[error("eth_getTransactionReceipt request error: {0}")]
     GetTransactionReceiptError(#[from] GetTransactionReceiptError),
     #[error("Failed to serialize request body: {0}")]
@@ -90,18 +88,6 @@ pub enum GetBlockNumberError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum GetLogsError {
-    #[error("{0}")]
-    ReqwestError(#[from] reqwest::Error),
-    #[error("{0}")]
-    SerdeJSONError(#[from] serde_json::Error),
-    #[error("{0}")]
-    RPCError(String),
-    #[error("{0}")]
-    ParseIntError(#[from] std::num::ParseIntError),
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum GasPriceError {
     #[error("{0}")]
     ReqwestError(#[from] reqwest::Error),
     #[error("{0}")]

--- a/crates/l2/utils/eth_client/mod.rs
+++ b/crates/l2/utils/eth_client/mod.rs
@@ -141,7 +141,7 @@ impl EthClient {
         }
     }
 
-    pub async fn get_gas_price(&self) -> Result<u64, EthClientError> {
+    pub async fn get_gas_price(&self) -> Result<U256, EthClientError> {
         let request = RpcRequest {
             id: RpcRequestId::Number(1),
             jsonrpc: "2.0".to_string(),
@@ -150,13 +150,9 @@ impl EthClient {
         };
 
         match self.send_request(request).await {
-            Ok(RpcResponse::Success(result)) => u64::from_str_radix(
-                &serde_json::from_value::<String>(result.result)
-                    .map_err(GetGasPriceError::SerdeJSONError)?[2..],
-                16,
-            )
-            .map_err(GetGasPriceError::ParseIntError)
-            .map_err(EthClientError::from),
+            Ok(RpcResponse::Success(result)) => serde_json::from_value(result.result)
+                .map_err(GetGasPriceError::SerdeJSONError)
+                .map_err(EthClientError::from),
             Ok(RpcResponse::Error(error_response)) => {
                 Err(GetGasPriceError::RPCError(error_response.error.message).into())
             }
@@ -225,25 +221,6 @@ impl EthClient {
                     "topics": [format!("{:#x}", topic)]
                 }
             )]),
-        };
-
-        match self.send_request(request).await {
-            Ok(RpcResponse::Success(result)) => serde_json::from_value(result.result)
-                .map_err(GetLogsError::SerdeJSONError)
-                .map_err(EthClientError::from),
-            Ok(RpcResponse::Error(error_response)) => {
-                Err(GetLogsError::RPCError(error_response.error.message).into())
-            }
-            Err(error) => Err(error),
-        }
-    }
-
-    pub async fn gas_price(&self) -> Result<U256, EthClientError> {
-        let request = RpcRequest {
-            id: RpcRequestId::Number(1),
-            jsonrpc: "2.0".to_string(),
-            method: "eth_gasPrice".to_string(),
-            params: None,
         };
 
         match self.send_request(request).await {


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
We accidentally write two implementations of the `eth_gasPrice` client.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Merge the implementations into one, keep the `get_gas_price` name to be coherent with the other methods.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #838 

