### PR TITLE
feat(levm): `STOP` opcode

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/arithmetic.rs
+++ b/crates/vm/levm/src/opcode_handlers/arithmetic.rs
@@ -1,18 +1,8 @@
-use crate::vm_result::ResultReason;
-
-// Stop and Arithmetic Operations (12)
-// Opcodes: STOP, ADD, SUB, MUL, DIV, SDIV, MOD, SMOD, ADDMOD, MULMOD, EXP, SIGNEXTEND
+// Arithmetic Operations (11)
+// Opcodes: ADD, SUB, MUL, DIV, SDIV, MOD, SMOD, ADDMOD, MULMOD, EXP, SIGNEXTEND
 use super::*;
 
 impl VM {
-    // STOP operation
-    pub fn op_stop(
-        &mut self,
-        current_call_frame: &mut CallFrame,
-    ) -> Result<OpcodeSuccess, VMError> {
-        self.call_frames.push(current_call_frame.clone());
-        Ok(OpcodeSuccess::Result(ResultReason::Stop))
-    }
     // ADD operation
     pub fn op_add(&mut self, current_call_frame: &mut CallFrame) -> Result<OpcodeSuccess, VMError> {
         if self.env.consumed_gas + gas_cost::ADD > self.env.tx_env.gas_limit {

--- a/crates/vm/levm/src/opcode_handlers/mod.rs
+++ b/crates/vm/levm/src/opcode_handlers/mod.rs
@@ -1,3 +1,4 @@
+pub mod arithmetic;
 pub mod bitwise_comparison;
 pub mod block;
 pub mod dup;
@@ -7,7 +8,6 @@ pub mod keccak;
 pub mod logging;
 pub mod push;
 pub mod stack_memory_storage_flow;
-pub mod stop_and_arithmetic;
 pub mod system;
 
 use crate::{

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -339,7 +339,7 @@ impl VM {
         loop {
             let opcode = current_call_frame.next_opcode().unwrap_or(Opcode::STOP);
             let op_result: Result<OpcodeSuccess, VMError> = match opcode {
-                Opcode::STOP => self.op_stop(&mut current_call_frame),
+                Opcode::STOP => Ok(OpcodeSuccess::Result(ResultReason::Stop)),
                 Opcode::ADD => self.op_add(&mut current_call_frame),
                 Opcode::MUL => self.op_mul(&mut current_call_frame),
                 Opcode::SUB => self.op_sub(&mut current_call_frame),


### PR DESCRIPTION
**Description**
Just a small refactor on `STOP` opcode. Removes unnecessary `op_stop` function.
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #456