### PR TITLE
feat(l1, l2): apply fork choice even when `PayloadAttributes` are invalid

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -37,7 +37,7 @@ jobs:
             run_command:  make run-hive SIMULATION=ethereum/engine TEST_PATTERN="/Blob Transactions On Block 1, Cancun Genesis|Blob Transactions On Block 1, Shanghai Genesis|Blob Transaction Ordering, Single Account, Single Blob|Blob Transaction Ordering, Single Account, Dual Blob|Blob Transaction Ordering, Multiple Accounts|Replace Blob Transactions|Parallel Blob Transactions|ForkchoiceUpdatedV3 Modifies Payload ID on Different Beacon Root|NewPayloadV3 After Cancun|NewPayloadV3 Versioned Hashes|ForkchoiceUpdated Version on Payload Request"
           - simulation: engine-cancun
             name: "Cancun Engine tests"
-            run_command:  make run-hive SIMULATION=ethereum/engine TEST_PATTERN="cancun/Unique Payload ID|ParentHash equals BlockHash on NewPayload|Re-Execute Payload|Payload Build after New Invalid Payload|RPC|Build Payload with Invalid ChainID|Invalid PayloadAttributes, Zero timestamp, Syncing=False|Invalid PayloadAttributes, Parent timestamp, Syncing=False|Suggested Fee Recipient Test|PrevRandao Opcode Transactions Test"
+            run_command:  make run-hive SIMULATION=ethereum/engine TEST_PATTERN="cancun/Unique Payload ID|ParentHash equals BlockHash on NewPayload|Re-Execute Payload|Payload Build after New Invalid Payload|RPC|Build Payload with Invalid ChainID|Invalid PayloadAttributes, Zero timestamp, Syncing=False|Invalid PayloadAttributes, Parent timestamp, Syncing=False|Invalid PayloadAttributes, Missing BeaconRoot, Syncing=False|Suggested Fee Recipient Test|PrevRandao Opcode Transactions Test"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/crates/l2/utils/engine_client/mod.rs
+++ b/crates/l2/utils/engine_client/mod.rs
@@ -85,7 +85,7 @@ impl EngineClient {
     ) -> Result<ForkChoiceResponse, EngineClientError> {
         let request = ForkChoiceUpdatedV3 {
             fork_choice_state: state,
-            payload_attributes: Some(payload_attributes),
+            payload_attributes: Ok(Some(payload_attributes)),
         }
         .into();
 

--- a/crates/l2/utils/engine_client/mod.rs
+++ b/crates/l2/utils/engine_client/mod.rs
@@ -87,7 +87,10 @@ impl EngineClient {
             fork_choice_state: state,
             payload_attributes: Ok(Some(payload_attributes)),
         }
-        .into();
+        // This try_into should always succeed, as we put an Ok before, but we handle
+        // the error as a serialization error to avoid unwraps.
+        .try_into()
+        .map_err(EngineClientError::FailedToSerializeRequestBody)?;
 
         match self.send_request(request).await {
             Ok(RpcResponse::Success(result)) => serde_json::from_value(result.result)

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -24,18 +24,20 @@ pub struct ForkChoiceUpdatedV3 {
     pub payload_attributes: Result<Option<PayloadAttributesV3>, String>,
 }
 
-impl From<ForkChoiceUpdatedV3> for RpcRequest {
-    fn from(val: ForkChoiceUpdatedV3) -> Self {
-        RpcRequest {
-            method: "engine_forkchoiceUpdatedV3".to_string(),
-            params: Some(vec![
-                serde_json::json!(val.fork_choice_state),
-                // We add this unwrap because we should NEVER build an outgoing request
-                // with an error. It only represents errors from incoming requests
-                // that we need to handle.
-                serde_json::json!(val.payload_attributes.unwrap()),
-            ]),
-            ..Default::default()
+impl TryFrom<ForkChoiceUpdatedV3> for RpcRequest {
+    type Error = String;
+
+    fn try_from(val: ForkChoiceUpdatedV3) -> Result<Self, Self::Error> {
+        match val.payload_attributes {
+            Ok(attrs) => Ok(RpcRequest {
+                method: "engine_forkchoiceUpdatedV3".to_string(),
+                params: Some(vec![
+                    serde_json::json!(val.fork_choice_state),
+                    serde_json::json!(attrs),
+                ]),
+                ..Default::default()
+            }),
+            Err(err) => Err(err),
         }
     }
 }


### PR DESCRIPTION
Changes

- Make payload attributes a result type in the request. This allows us to represent errors in the request that will be handled.
- `handle` now takes into account the possibility of payload attributes being an error, but only cares about it after fork choice has been applied.
- The L2 client has been updated to take this into account and uses `Ok(Some(attributes))` now. To the client user it will not notice the changes as the parameters of the function do not change.
- Re-add the missing beacon block root hive test, now correctly working.

Closes #853 

