### PR TITLE
feat(l1): implement hello messages exchange after handshake

### DIFF
--- a/crates/networking/p2p/Cargo.toml
+++ b/crates/networking/p2p/Cargo.toml
@@ -14,6 +14,7 @@ tracing.workspace = true
 tokio.workspace = true
 bytes.workspace = true
 hex.workspace = true
+thiserror.workspace = true
 
 k256 = { version = "0.13.3", features = ["ecdh"] }
 sha3 = "0.10.8"

--- a/crates/networking/p2p/net.rs
+++ b/crates/networking/p2p/net.rs
@@ -788,15 +788,19 @@ async fn handle_peer_as_initiator(signer: SigningKey, msg: &[u8], node: &Node) {
 }
 
 async fn handle_peer(mut conn: RLPxConnection<TcpStream>) {
-    conn.handshake().await;
-    // TODO react on handshake or capabilities exchange result
-    // https://github.com/lambdaclass/lambda_ethereum_rust/issues/841
-
-    // TODO Properly build listen loop
-    // https://github.com/lambdaclass/lambda_ethereum_rust/issues/840
-    // loop {
-    //     conn.await_messages();
-    // }
+    match conn.handshake().await {
+        Ok(_) => {
+            // TODO Properly build listen loop
+            // https://github.com/lambdaclass/lambda_ethereum_rust/issues/840
+            // loop {
+            //     conn.await_messages();
+            // }
+        }
+        Err(e) => {
+            // TODO propagate error to eventually discard peer from kademlia table
+            info!("Handshake failed, discarding peer: ({e})");
+        }
+    }
 }
 
 pub fn node_id_from_signing_key(signer: &SigningKey) -> H512 {

--- a/crates/networking/p2p/rlpx.rs
+++ b/crates/networking/p2p/rlpx.rs
@@ -1,4 +1,5 @@
 pub mod connection;
+pub mod error;
 pub mod eth;
 pub mod frame;
 pub mod handshake;

--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 
 use super::{
+    error::RLPxError,
     frame,
     handshake::{decode_ack_message, decode_auth_message, encode_auth_message},
     message as rlpx,
@@ -20,7 +21,6 @@ use k256::{
 use sha3::{Digest, Keccak256};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tracing::{error, info};
-// pub const SUPPORTED_CAPABILITIES: [(&str, u8); 1] = [("p2p", 5)];
 pub const SUPPORTED_CAPABILITIES: [(&str, u8); 2] = [("p2p", 5), ("eth", 68)];
 // pub const SUPPORTED_CAPABILITIES: [(&str, u8); 3] = [("p2p", 5), ("eth", 68), ("snap", 1)];
 
@@ -31,7 +31,7 @@ pub(crate) struct RLPxConnection<S> {
     signer: SigningKey,
     state: RLPxConnectionState,
     stream: S,
-    // ...capabilities information
+    capabilities: Vec<(String, u8)>,
 }
 
 impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
@@ -40,6 +40,7 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
             signer,
             state,
             stream,
+            capabilities: vec![],
         }
     }
 
@@ -69,7 +70,7 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
         RLPxConnection::new(signer, stream, state)
     }
 
-    pub async fn handshake(&mut self) {
+    pub async fn handshake(&mut self) -> Result<(), RLPxError> {
         match &self.state {
             RLPxConnectionState::Initiator(_) => {
                 self.send_auth().await;
@@ -79,12 +80,17 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
                 self.receive_auth().await;
                 self.send_ack().await;
             }
-            _ => panic!("Invalid state for handshake"),
-        }
+            _ => {
+                return Err(RLPxError::HandshakeError(
+                    "Invalid connection state for handshake".to_string(),
+                ))
+            }
+        };
         info!("Completed handshake!");
 
-        self.exchange_hello_messages().await;
+        self.exchange_hello_messages().await?;
         info!("Completed Hello roundtrip!");
+        Ok(())
     }
 
     pub async fn send_auth(&mut self) {
@@ -214,12 +220,13 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
         };
     }
 
-    pub async fn exchange_hello_messages(&mut self) {
+    pub async fn exchange_hello_messages(&mut self) -> Result<(), RLPxError> {
+        let supported_capabilities: Vec<(String, u8)> = SUPPORTED_CAPABILITIES
+            .into_iter()
+            .map(|(name, version)| (name.to_string(), version))
+            .collect();
         let hello_msg = Message::Hello(p2p::HelloMessage::new(
-            SUPPORTED_CAPABILITIES
-                .into_iter()
-                .map(|(name, version)| (name.to_string(), version))
-                .collect(),
+            supported_capabilities.clone(),
             PublicKey::from(self.signer.verifying_key()),
         ));
 
@@ -229,13 +236,25 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
         // Receive Hello message
         match self.receive().await {
             Message::Hello(hello_message) => {
-                // TODO, register shared capabilities
-                // https://github.com/lambdaclass/lambda_ethereum_rust/issues/841
                 info!("Hello message received {hello_message:?}");
+                self.capabilities = hello_message.capabilities;
+
+                // Check if we have any capability in common
+                for cap in self.capabilities.clone() {
+                    if supported_capabilities.contains(&cap) {
+                        return Ok(());
+                    }
+                }
+                // Return error if not
+                Err(RLPxError::HandshakeError(
+                    "No matching capabilities".to_string(),
+                ))
             }
             _ => {
-                // if it is not a hello message panic
-                panic!("Expected Hello message")
+                // Fail if it is not a hello message
+                Err(RLPxError::HandshakeError(
+                    "Expected Hello message".to_string(),
+                ))
             }
         }
     }

--- a/crates/networking/p2p/rlpx/error.rs
+++ b/crates/networking/p2p/rlpx/error.rs
@@ -1,0 +1,8 @@
+use thiserror::Error;
+
+// TODO improve errors
+#[derive(Debug, Error)]
+pub enum RLPxError {
+    #[error("{0}")]
+    HandshakeError(String),
+}

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -14,8 +14,8 @@ use super::{message::RLPxMessage, utils::pubkey2id};
 
 #[derive(Debug)]
 pub(crate) struct HelloMessage {
-    capabilities: Vec<(String, u8)>,
-    node_id: PublicKey,
+    pub(crate) capabilities: Vec<(String, u8)>,
+    pub(crate) node_id: PublicKey,
 }
 
 impl HelloMessage {


### PR DESCRIPTION
**Motivation**
After an RLPx handshake peers exchange `Hello` messages that provide information on capabilities each node support. A check is made to ensure we share at least one capability with matching version.

**Description**

- Saves the peer capability list in the RLPxConnection struct
- Checks if we have capabilities in common with the remote peer and return an error if not

Resolves #841 

