### PR TITLE
feat(l1): add libmdbx features 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           cargo fmt --all -- --check
 
-  test:
+  prover:
     name: Test
     runs-on: ubuntu-latest
     steps:
@@ -76,7 +76,7 @@ jobs:
           file: ./Dockerfile
           load: true # Important for building without pushing
 
-  prover:
+  test:
     name: Build RISC-V zkVM program
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,5 +95,5 @@ jobs:
 
       - name: Build program
         run: |
-          cd crates/l2
-          make setup-prover
+          cd crates/l2/prover/sp1/program
+          ~/.sp1/bin/cargo-prove prove build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,11 +77,8 @@ jobs:
           load: true # Important for building without pushing
 
   prover:
-    strategy:
-      fail-fast: true
-
     name: Build RISC-V zkVM program
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
       - uses: actions/checkout@v3
@@ -97,6 +94,6 @@ jobs:
           ~/.config/.sp1/bin/sp1up
 
       - name: Build program
-        working-directory: ./crates/l2
         run: |
+          cd crates/l2
           make setup-prover

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,3 +75,28 @@ jobs:
           context: .
           file: ./Dockerfile
           load: true # Important for building without pushing
+
+  prover:
+    strategy:
+      fail-fast: true
+
+    name: Build RISC-V zkVM program
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout sources
+      - uses: actions/checkout@v3
+
+      - name: Rust toolchain install
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: SP1 toolchain install
+        run: |
+          curl -L https://sp1.succinct.xyz | bash
+          ~/.config/.sp1/bin/sp1up
+
+      - name: Build program
+        working-directory: ./crates/l2
+        run: |
+          make setup-prover

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
 
-      - name: SP1 toolchain install
+      - name: RISC-V zkVM toolchain install
         run: |
           curl -L https://sp1.succinct.xyz | bash
           ~/.sp1/bin/sp1up

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: SP1 toolchain install
         run: |
           curl -L https://sp1.succinct.xyz | bash
-          ~/.config/.sp1/bin/sp1up
+          ~/.sp1/bin/sp1up
 
       - name: Build program
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           cargo fmt --all -- --check
 
-  prover:
+  test:
     name: Test
     runs-on: ubuntu-latest
     steps:
@@ -76,7 +76,7 @@ jobs:
           file: ./Dockerfile
           load: true # Important for building without pushing
 
-  test:
+  prover:
     name: Build RISC-V zkVM program
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
 
       - name: Rust toolchain install
         uses: dtolnay/rust-toolchain@stable

--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -7,15 +7,14 @@ edition = "2021"
 
 [dependencies]
 thiserror.workspace = true
-ethereum_rust-rlp.workspace = true
 sha3.workspace = true
 tracing.workspace = true
+bytes.workspace = true
 
+ethereum_rust-rlp.workspace = true
 ethereum_rust-core = { path = "../common", default-features = false }
 ethereum_rust-storage = { path = "../storage/store", default-features = false }
 ethereum_rust-vm = { path = "../vm", default-features = false }
-
-bytes.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -7,12 +7,14 @@ edition = "2021"
 
 [dependencies]
 thiserror.workspace = true
-ethereum_rust-core.workspace = true
 ethereum_rust-rlp.workspace = true
-ethereum_rust-storage.workspace = true
-ethereum_rust-vm.workspace = true
 sha3.workspace = true
 tracing.workspace = true
+
+ethereum_rust-core = { path = "../common", default-features = false }
+ethereum_rust-storage = { path = "../storage/store", default-features = false }
+ethereum_rust-vm = { path = "../vm", default-features = false }
+
 bytes.workspace = true
 
 [dev-dependencies]
@@ -20,3 +22,11 @@ serde_json.workspace = true
 
 [lib]
 path = "./blockchain.rs"
+
+[features]
+default = ["libmdbx"]
+libmdbx = [
+    "ethereum_rust-core/libmdbx",
+    "ethereum_rust-storage/default",
+    "ethereum_rust-vm/libmdbx",
+]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 
 [dependencies]
 ethereum_rust-rlp.workspace = true
-ethereum_rust-trie.workspace = true
+ethereum_rust-trie = { path = "../storage/trie", default-features = false }
+
 tinyvec = "1.6.0"
 ethereum-types.workspace = true
 serde.workspace = true
@@ -26,6 +27,10 @@ lazy_static.workspace = true
 
 [dev-dependencies]
 hex-literal.workspace = true
+
+[features]
+default = ["libmdbx"]
+libmdbx = ["ethereum_rust-trie/libmdbx"]
 
 [lib]
 path = "./core.rs"

--- a/crates/common/types/block.rs
+++ b/crates/common/types/block.rs
@@ -28,7 +28,7 @@ use lazy_static::lazy_static;
 lazy_static! {
     pub static ref DEFAULT_OMMERS_HASH: H256 = H256::from_slice(&hex::decode("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347").unwrap()); // = Keccak256(RLP([])) as of EIP-3675
 }
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize, Default)]
 pub struct Block {
     pub header: BlockHeader,
     pub body: BlockBody,
@@ -68,9 +68,9 @@ impl RLPDecode for Block {
 #[serde(rename_all = "camelCase")]
 pub struct BlockHeader {
     pub parent_hash: H256,
-    #[serde(rename(serialize = "sha3Uncles"))]
+    #[serde(rename = "sha3Uncles")]
     pub ommers_hash: H256, // ommer = uncle
-    #[serde(rename(serialize = "miner"))]
+    #[serde(rename = "miner")]
     pub coinbase: Address,
     pub state_root: H256,
     pub transactions_root: H256,
@@ -88,16 +88,24 @@ pub struct BlockHeader {
     pub timestamp: u64,
     #[serde(with = "crate::serde_utils::bytes")]
     pub extra_data: Bytes,
-    #[serde(rename(serialize = "mixHash"))]
+    #[serde(rename = "mixHash")]
     pub prev_randao: H256,
     #[serde(with = "crate::serde_utils::u64::hex_str_padding")]
     pub nonce: u64,
     #[serde(with = "crate::serde_utils::u64::hex_str_opt")]
     pub base_fee_per_gas: Option<u64>,
     pub withdrawals_root: Option<H256>,
-    #[serde(with = "crate::serde_utils::u64::hex_str_opt")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        with = "crate::serde_utils::u64::hex_str_opt",
+        default = "Option::default"
+    )]
     pub blob_gas_used: Option<u64>,
-    #[serde(with = "crate::serde_utils::u64::hex_str_opt")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        with = "crate::serde_utils::u64::hex_str_opt",
+        default = "Option::default"
+    )]
     pub excess_blob_gas: Option<u64>,
     pub parent_beacon_block_root: Option<H256>,
 }
@@ -183,11 +191,11 @@ impl RLPDecode for BlockHeader {
 }
 
 // The body of a block on the chain
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct BlockBody {
     pub transactions: Vec<Transaction>,
     // TODO: ommers list is always empty, so we can remove it
-    #[serde(rename(serialize = "uncles"))]
+    #[serde(rename = "uncles")]
     pub ommers: Vec<BlockHeader>,
     pub withdrawals: Option<Vec<Withdrawal>>,
 }

--- a/crates/common/types/receipt.rs
+++ b/crates/common/types/receipt.rs
@@ -12,7 +12,7 @@ use super::TxType;
 pub type Index = u64;
 
 /// Result of a transaction
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Receipt {
     pub tx_type: TxType,
     pub succeeded: bool,

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -768,6 +768,7 @@ mod canonic_encoding {
 }
 
 // Serialization
+// This is used for RPC messaging and passing data into a RISC-V zkVM
 
 mod serde_impl {
     use serde::Deserialize;

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use ethereum_types::{Address, H256, U256};
 pub use mempool::MempoolTransaction;
 use secp256k1::{ecdsa::RecoveryId, Message, SECP256K1};
-use serde::{ser::SerializeStruct, Serialize};
+use serde::{ser::SerializeStruct, Deserialize, Serialize};
 pub use serde_impl::{AccessListEntry, GenericTransaction};
 use sha3::{Digest, Keccak256};
 
@@ -1099,6 +1099,95 @@ mod serde_impl {
                 gas_price: serde_json::from_value::<U256>(
                     map.remove("gasPrice")
                         .ok_or_else(|| serde::de::Error::missing_field("gasPrice"))?,
+                )
+                .map_err(serde::de::Error::custom)?
+                .as_u64(),
+                gas_limit: serde_json::from_value::<U256>(
+                    map.remove("gas")
+                        .ok_or_else(|| serde::de::Error::missing_field("gas"))?,
+                )
+                .map_err(serde::de::Error::custom)?
+                .as_u64(),
+                to,
+                value,
+                data,
+                access_list: serde_json::from_value(
+                    map.remove("accessList")
+                        .ok_or_else(|| serde::de::Error::missing_field("accessList"))?,
+                )
+                .map_err(serde::de::Error::custom)?,
+                signature_y_parity: u8::from_str_radix(
+                    serde_json::from_value::<String>(
+                        map.remove("yParity")
+                            .ok_or_else(|| serde::de::Error::missing_field("yParity"))?,
+                    )
+                    .map_err(serde::de::Error::custom)?
+                    .trim_start_matches("0x"),
+                    16,
+                )
+                .map_err(serde::de::Error::custom)?
+                    != 0,
+                signature_r: r,
+                signature_s: s,
+            })
+        }
+    }
+
+    impl<'de> Deserialize<'de> for EIP1559Transaction {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            let mut map = <HashMap<String, serde_json::Value>>::deserialize(deserializer)?;
+            let nonce = serde_json::from_value::<U256>(
+                map.remove("nonce")
+                    .ok_or_else(|| serde::de::Error::missing_field("nonce"))?,
+            )
+            .map_err(serde::de::Error::custom)?
+            .as_u64();
+            let to = serde_json::from_value(
+                map.remove("to")
+                    .ok_or_else(|| serde::de::Error::missing_field("to"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let value = serde_json::from_value(
+                map.remove("value")
+                    .ok_or_else(|| serde::de::Error::missing_field("value"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let data = serde_json::from_value(
+                map.remove("input")
+                    .ok_or_else(|| serde::de::Error::missing_field("input"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let r = serde_json::from_value(
+                map.remove("r")
+                    .ok_or_else(|| serde::de::Error::missing_field("r"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let s = serde_json::from_value(
+                map.remove("s")
+                    .ok_or_else(|| serde::de::Error::missing_field("s"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+
+            Ok(EIP1559Transaction {
+                chain_id: serde_json::from_value::<U256>(
+                    map.remove("chainId")
+                        .ok_or_else(|| serde::de::Error::missing_field("chainId"))?,
+                )
+                .map_err(serde::de::Error::custom)?
+                .as_u64(),
+                nonce,
+                max_priority_fee_per_gas: serde_json::from_value::<U256>(
+                    map.remove("maxPriorityFeePerGas")
+                        .ok_or_else(|| serde::de::Error::missing_field("maxPriorityFeePerGas"))?,
+                )
+                .map_err(serde::de::Error::custom)?
+                .as_u64(),
+                max_fee_per_gas: serde_json::from_value::<U256>(
+                    map.remove("maxFeePerGas")
+                        .ok_or_else(|| serde::de::Error::missing_field("maxFeePerGas"))?,
                 )
                 .map_err(serde::de::Error::custom)?
                 .as_u64(),

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use ethereum_types::{Address, H256, U256};
 pub use mempool::MempoolTransaction;
 use secp256k1::{ecdsa::RecoveryId, Message, SECP256K1};
-use serde::{ser::SerializeStruct, Deserialize, Serialize};
+use serde::{ser::SerializeStruct, Serialize};
 pub use serde_impl::{AccessListEntry, GenericTransaction};
 use sha3::{Digest, Keccak256};
 
@@ -55,7 +55,7 @@ pub struct EIP2930Transaction {
     pub signature_s: U256,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Default, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct EIP1559Transaction {
     pub chain_id: u64,
     pub nonce: u64,

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -16,7 +16,7 @@ use ethereum_rust_rlp::{
     structs::{Decoder, Encoder},
 };
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Transaction {
     LegacyTransaction(LegacyTransaction),
@@ -71,7 +71,6 @@ pub struct EIP1559Transaction {
     pub signature_s: U256,
 }
 
-// TODO/FIXME: We must implement a custom Deserialize
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct EIP4844Transaction {
     pub chain_id: u64,
@@ -940,174 +939,6 @@ mod serde_impl {
         }
     }
 
-    impl<'de> Deserialize<'de> for Transaction {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: serde::Deserializer<'de>,
-        {
-            let mut map = <HashMap<String, serde_json::Value>>::deserialize(deserializer)?;
-            let tx_type = serde_json::from_value::<TxType>(
-                map.remove("type")
-                    .ok_or_else(|| serde::de::Error::missing_field("type"))?,
-            )
-            .map_err(serde::de::Error::custom)?;
-            let nonce = serde_json::from_value::<U256>(
-                map.remove("nonce")
-                    .ok_or_else(|| serde::de::Error::missing_field("nonce"))?,
-            )
-            .map_err(serde::de::Error::custom)?
-            .as_u64();
-            let to = serde_json::from_value(
-                map.remove("to")
-                    .ok_or_else(|| serde::de::Error::missing_field("to"))?,
-            )
-            .map_err(serde::de::Error::custom)?;
-            let value = serde_json::from_value(
-                map.remove("value")
-                    .ok_or_else(|| serde::de::Error::missing_field("value"))?,
-            )
-            .map_err(serde::de::Error::custom)?;
-            let data = serde_json::from_value(
-                map.remove("input")
-                    .ok_or_else(|| serde::de::Error::missing_field("input"))?,
-            )
-            .map_err(serde::de::Error::custom)?;
-            let r = serde_json::from_value(
-                map.remove("r")
-                    .ok_or_else(|| serde::de::Error::missing_field("r"))?,
-            )
-            .map_err(serde::de::Error::custom)?;
-            let s = serde_json::from_value(
-                map.remove("s")
-                    .ok_or_else(|| serde::de::Error::missing_field("s"))?,
-            )
-            .map_err(serde::de::Error::custom)?;
-
-            let tx = match tx_type {
-                TxType::Legacy => Self::LegacyTransaction(LegacyTransaction {
-                    nonce,
-                    gas_price: serde_json::from_value::<U256>(
-                        map.remove("gasPrice")
-                            .ok_or_else(|| serde::de::Error::missing_field("gasPrice"))?,
-                    )
-                    .map_err(serde::de::Error::custom)?
-                    .as_u64(),
-                    gas: serde_json::from_value::<U256>(
-                        map.remove("gas")
-                            .ok_or_else(|| serde::de::Error::missing_field("gas"))?,
-                    )
-                    .map_err(serde::de::Error::custom)?
-                    .as_u64(),
-                    to,
-                    value,
-                    data,
-                    v: serde_json::from_value(
-                        map.remove("v")
-                            .ok_or_else(|| serde::de::Error::missing_field("v"))?,
-                    )
-                    .map_err(serde::de::Error::custom)?,
-                    r,
-                    s,
-                }),
-                TxType::EIP2930 => Self::EIP2930Transaction(EIP2930Transaction {
-                    chain_id: serde_json::from_value::<U256>(
-                        map.remove("chainId")
-                            .ok_or_else(|| serde::de::Error::missing_field("chainId"))?,
-                    )
-                    .map_err(serde::de::Error::custom)?
-                    .as_u64(),
-                    nonce,
-                    gas_price: serde_json::from_value::<U256>(
-                        map.remove("gasPrice")
-                            .ok_or_else(|| serde::de::Error::missing_field("gasPrice"))?,
-                    )
-                    .map_err(serde::de::Error::custom)?
-                    .as_u64(),
-                    gas_limit: serde_json::from_value::<U256>(
-                        map.remove("gas")
-                            .ok_or_else(|| serde::de::Error::missing_field("gas"))?,
-                    )
-                    .map_err(serde::de::Error::custom)?
-                    .as_u64(),
-                    to,
-                    value,
-                    data,
-                    access_list: serde_json::from_value(
-                        map.remove("accessList")
-                            .ok_or_else(|| serde::de::Error::missing_field("accessList"))?,
-                    )
-                    .map_err(serde::de::Error::custom)?,
-                    signature_y_parity: u8::from_str_radix(
-                        serde_json::from_value::<String>(
-                            map.remove("yParity")
-                                .ok_or_else(|| serde::de::Error::missing_field("yParity"))?,
-                        )
-                        .map_err(serde::de::Error::custom)?
-                        .trim_start_matches("0x"),
-                        16,
-                    )
-                    .map_err(serde::de::Error::custom)?
-                        != 0,
-                    signature_r: r,
-                    signature_s: s,
-                }),
-                TxType::EIP1559 => Self::EIP1559Transaction(EIP1559Transaction {
-                    chain_id: serde_json::from_value::<U256>(
-                        map.remove("chainId")
-                            .ok_or_else(|| serde::de::Error::missing_field("chainId"))?,
-                    )
-                    .map_err(serde::de::Error::custom)?
-                    .as_u64(),
-                    nonce,
-                    max_priority_fee_per_gas: serde_json::from_value::<U256>(
-                        map.remove("maxPriorityFeePerGas").ok_or_else(|| {
-                            serde::de::Error::missing_field("maxPriorityFeePerGas")
-                        })?,
-                    )
-                    .map_err(serde::de::Error::custom)?
-                    .as_u64(),
-                    max_fee_per_gas: serde_json::from_value::<U256>(
-                        map.remove("maxFeePerGas")
-                            .ok_or_else(|| serde::de::Error::missing_field("maxFeePerGas"))?,
-                    )
-                    .map_err(serde::de::Error::custom)?
-                    .as_u64(),
-                    gas_limit: serde_json::from_value::<U256>(
-                        map.remove("gas")
-                            .ok_or_else(|| serde::de::Error::missing_field("gas"))?,
-                    )
-                    .map_err(serde::de::Error::custom)?
-                    .as_u64(),
-                    to,
-                    value,
-                    data,
-                    access_list: serde_json::from_value(
-                        map.remove("accessList")
-                            .ok_or_else(|| serde::de::Error::missing_field("accessList"))?,
-                    )
-                    .map_err(serde::de::Error::custom)?,
-                    signature_y_parity: u8::from_str_radix(
-                        serde_json::from_value::<String>(
-                            map.remove("yParity")
-                                .ok_or_else(|| serde::de::Error::missing_field("yParity"))?,
-                        )
-                        .map_err(serde::de::Error::custom)?
-                        .trim_start_matches("0x"),
-                        16,
-                    )
-                    .map_err(serde::de::Error::custom)?
-                        != 0,
-                    signature_r: r,
-                    signature_s: s,
-                }),
-                TxType::EIP4844 => Err(serde::de::Error::custom(
-                    "EIP4844 transaction deserialization",
-                ))?,
-            };
-            Ok(tx)
-        }
-    }
-
     impl Serialize for EIP4844Transaction {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
@@ -1150,6 +981,166 @@ mod serde_impl {
             struct_serializer.serialize_field("r", &self.signature_r)?;
             struct_serializer.serialize_field("s", &self.signature_s)?;
             struct_serializer.end()
+        }
+    }
+
+    impl<'de> Deserialize<'de> for LegacyTransaction {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            let mut map = <HashMap<String, serde_json::Value>>::deserialize(deserializer)?;
+            let nonce = serde_json::from_value::<U256>(
+                map.remove("nonce")
+                    .ok_or_else(|| serde::de::Error::missing_field("nonce"))?,
+            )
+            .map_err(serde::de::Error::custom)?
+            .as_u64();
+            let to = serde_json::from_value(
+                map.remove("to")
+                    .ok_or_else(|| serde::de::Error::missing_field("to"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let value = serde_json::from_value(
+                map.remove("value")
+                    .ok_or_else(|| serde::de::Error::missing_field("value"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let data = serde_json::from_value(
+                map.remove("input")
+                    .ok_or_else(|| serde::de::Error::missing_field("input"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let r = serde_json::from_value(
+                map.remove("r")
+                    .ok_or_else(|| serde::de::Error::missing_field("r"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let s = serde_json::from_value(
+                map.remove("s")
+                    .ok_or_else(|| serde::de::Error::missing_field("s"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+
+            Ok(LegacyTransaction {
+                nonce,
+                gas_price: serde_json::from_value::<U256>(
+                    map.remove("gasPrice")
+                        .ok_or_else(|| serde::de::Error::missing_field("gasPrice"))?,
+                )
+                .map_err(serde::de::Error::custom)?
+                .as_u64(),
+                gas: serde_json::from_value::<U256>(
+                    map.remove("gas")
+                        .ok_or_else(|| serde::de::Error::missing_field("gas"))?,
+                )
+                .map_err(serde::de::Error::custom)?
+                .as_u64(),
+                to,
+                value,
+                data,
+                v: serde_json::from_value(
+                    map.remove("v")
+                        .ok_or_else(|| serde::de::Error::missing_field("v"))?,
+                )
+                .map_err(serde::de::Error::custom)?,
+                r,
+                s,
+            })
+        }
+    }
+
+    impl<'de> Deserialize<'de> for EIP2930Transaction {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            let mut map = <HashMap<String, serde_json::Value>>::deserialize(deserializer)?;
+            let nonce = serde_json::from_value::<U256>(
+                map.remove("nonce")
+                    .ok_or_else(|| serde::de::Error::missing_field("nonce"))?,
+            )
+            .map_err(serde::de::Error::custom)?
+            .as_u64();
+            let to = serde_json::from_value(
+                map.remove("to")
+                    .ok_or_else(|| serde::de::Error::missing_field("to"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let value = serde_json::from_value(
+                map.remove("value")
+                    .ok_or_else(|| serde::de::Error::missing_field("value"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let data = serde_json::from_value(
+                map.remove("input")
+                    .ok_or_else(|| serde::de::Error::missing_field("input"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let r = serde_json::from_value(
+                map.remove("r")
+                    .ok_or_else(|| serde::de::Error::missing_field("r"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let s = serde_json::from_value(
+                map.remove("s")
+                    .ok_or_else(|| serde::de::Error::missing_field("s"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+
+            Ok(EIP2930Transaction {
+                chain_id: serde_json::from_value::<U256>(
+                    map.remove("chainId")
+                        .ok_or_else(|| serde::de::Error::missing_field("chainId"))?,
+                )
+                .map_err(serde::de::Error::custom)?
+                .as_u64(),
+                nonce,
+                gas_price: serde_json::from_value::<U256>(
+                    map.remove("gasPrice")
+                        .ok_or_else(|| serde::de::Error::missing_field("gasPrice"))?,
+                )
+                .map_err(serde::de::Error::custom)?
+                .as_u64(),
+                gas_limit: serde_json::from_value::<U256>(
+                    map.remove("gas")
+                        .ok_or_else(|| serde::de::Error::missing_field("gas"))?,
+                )
+                .map_err(serde::de::Error::custom)?
+                .as_u64(),
+                to,
+                value,
+                data,
+                access_list: serde_json::from_value(
+                    map.remove("accessList")
+                        .ok_or_else(|| serde::de::Error::missing_field("accessList"))?,
+                )
+                .map_err(serde::de::Error::custom)?,
+                signature_y_parity: u8::from_str_radix(
+                    serde_json::from_value::<String>(
+                        map.remove("yParity")
+                            .ok_or_else(|| serde::de::Error::missing_field("yParity"))?,
+                    )
+                    .map_err(serde::de::Error::custom)?
+                    .trim_start_matches("0x"),
+                    16,
+                )
+                .map_err(serde::de::Error::custom)?
+                    != 0,
+                signature_r: r,
+                signature_s: s,
+            })
+        }
+    }
+
+    impl<'de> Deserialize<'de> for EIP4844Transaction {
+        fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            Err(serde::de::Error::custom(
+                "EIP4844Transaction deserialization unimplemented",
+            ))
         }
     }
 

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use ethereum_types::{Address, H256, U256};
 pub use mempool::MempoolTransaction;
 use secp256k1::{ecdsa::RecoveryId, Message, SECP256K1};
-use serde::{ser::SerializeStruct, Serialize};
+use serde::{ser::SerializeStruct, Deserialize, Serialize};
 pub use serde_impl::{AccessListEntry, GenericTransaction};
 use sha3::{Digest, Keccak256};
 
@@ -55,7 +55,7 @@ pub struct EIP2930Transaction {
     pub signature_s: U256,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Deserialize)]
 pub struct EIP1559Transaction {
     pub chain_id: u64,
     pub nonce: u64,
@@ -71,6 +71,7 @@ pub struct EIP1559Transaction {
     pub signature_s: U256,
 }
 
+// TODO/FIXME: We must implement a custom Deserialize
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct EIP4844Transaction {
     pub chain_id: u64,
@@ -771,7 +772,7 @@ mod canonic_encoding {
 
 mod serde_impl {
     use serde::Deserialize;
-    use std::str::FromStr;
+    use std::{collections::HashMap, str::FromStr};
 
     use super::*;
 
@@ -936,6 +937,172 @@ mod serde_impl {
             struct_serializer.serialize_field("r", &self.signature_r)?;
             struct_serializer.serialize_field("s", &self.signature_s)?;
             struct_serializer.end()
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Transaction {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            let mut map = <HashMap<String, serde_json::Value>>::deserialize(deserializer)?;
+            let tx_type = serde_json::from_value::<TxType>(
+                map.remove("type")
+                    .ok_or_else(|| serde::de::Error::missing_field("type"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let nonce = serde_json::from_value::<U256>(
+                map.remove("nonce")
+                    .ok_or_else(|| serde::de::Error::missing_field("nonce"))?,
+            )
+            .map_err(serde::de::Error::custom)?
+            .as_u64();
+            let to = serde_json::from_value(
+                map.remove("to")
+                    .ok_or_else(|| serde::de::Error::missing_field("to"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let value = serde_json::from_value(
+                map.remove("value")
+                    .ok_or_else(|| serde::de::Error::missing_field("value"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let data = serde_json::from_value(
+                map.remove("input")
+                    .ok_or_else(|| serde::de::Error::missing_field("input"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let r = serde_json::from_value(
+                map.remove("r")
+                    .ok_or_else(|| serde::de::Error::missing_field("r"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+            let s = serde_json::from_value(
+                map.remove("s")
+                    .ok_or_else(|| serde::de::Error::missing_field("s"))?,
+            )
+            .map_err(serde::de::Error::custom)?;
+
+            let tx = match tx_type {
+                TxType::Legacy => Self::LegacyTransaction(LegacyTransaction {
+                    nonce,
+                    gas_price: serde_json::from_value::<U256>(
+                        map.remove("gasPrice")
+                            .ok_or_else(|| serde::de::Error::missing_field("gasPrice"))?,
+                    )
+                    .map_err(serde::de::Error::custom)?
+                    .as_u64(),
+                    gas: serde_json::from_value::<U256>(
+                        map.remove("gas")
+                            .ok_or_else(|| serde::de::Error::missing_field("gas"))?,
+                    )
+                    .map_err(serde::de::Error::custom)?
+                    .as_u64(),
+                    to,
+                    value,
+                    data,
+                    v: serde_json::from_value(
+                        map.remove("v")
+                            .ok_or_else(|| serde::de::Error::missing_field("v"))?,
+                    )
+                    .map_err(serde::de::Error::custom)?,
+                    r,
+                    s,
+                }),
+                TxType::EIP2930 => Self::EIP2930Transaction(EIP2930Transaction {
+                    chain_id: serde_json::from_value::<U256>(
+                        map.remove("chainId")
+                            .ok_or_else(|| serde::de::Error::missing_field("chainId"))?,
+                    )
+                    .map_err(serde::de::Error::custom)?
+                    .as_u64(),
+                    nonce,
+                    gas_price: serde_json::from_value::<U256>(
+                        map.remove("gasPrice")
+                            .ok_or_else(|| serde::de::Error::missing_field("gasPrice"))?,
+                    )
+                    .map_err(serde::de::Error::custom)?
+                    .as_u64(),
+                    gas_limit: serde_json::from_value::<U256>(
+                        map.remove("gas")
+                            .ok_or_else(|| serde::de::Error::missing_field("gas"))?,
+                    )
+                    .map_err(serde::de::Error::custom)?
+                    .as_u64(),
+                    to,
+                    value,
+                    data,
+                    access_list: serde_json::from_value(
+                        map.remove("accessList")
+                            .ok_or_else(|| serde::de::Error::missing_field("accessList"))?,
+                    )
+                    .map_err(serde::de::Error::custom)?,
+                    signature_y_parity: u8::from_str_radix(
+                        serde_json::from_value::<String>(
+                            map.remove("yParity")
+                                .ok_or_else(|| serde::de::Error::missing_field("yParity"))?,
+                        )
+                        .map_err(serde::de::Error::custom)?
+                        .trim_start_matches("0x"),
+                        16,
+                    )
+                    .map_err(serde::de::Error::custom)?
+                        != 0,
+                    signature_r: r,
+                    signature_s: s,
+                }),
+                TxType::EIP1559 => Self::EIP1559Transaction(EIP1559Transaction {
+                    chain_id: serde_json::from_value::<U256>(
+                        map.remove("chainId")
+                            .ok_or_else(|| serde::de::Error::missing_field("chainId"))?,
+                    )
+                    .map_err(serde::de::Error::custom)?
+                    .as_u64(),
+                    nonce,
+                    max_priority_fee_per_gas: serde_json::from_value::<U256>(
+                        map.remove("maxPriorityFeePerGas").ok_or_else(|| {
+                            serde::de::Error::missing_field("maxPriorityFeePerGas")
+                        })?,
+                    )
+                    .map_err(serde::de::Error::custom)?
+                    .as_u64(),
+                    max_fee_per_gas: serde_json::from_value::<U256>(
+                        map.remove("maxFeePerGas")
+                            .ok_or_else(|| serde::de::Error::missing_field("maxFeePerGas"))?,
+                    )
+                    .map_err(serde::de::Error::custom)?
+                    .as_u64(),
+                    gas_limit: serde_json::from_value::<U256>(
+                        map.remove("gas")
+                            .ok_or_else(|| serde::de::Error::missing_field("gas"))?,
+                    )
+                    .map_err(serde::de::Error::custom)?
+                    .as_u64(),
+                    to,
+                    value,
+                    data,
+                    access_list: serde_json::from_value(
+                        map.remove("accessList")
+                            .ok_or_else(|| serde::de::Error::missing_field("accessList"))?,
+                    )
+                    .map_err(serde::de::Error::custom)?,
+                    signature_y_parity: u8::from_str_radix(
+                        serde_json::from_value::<String>(
+                            map.remove("yParity")
+                                .ok_or_else(|| serde::de::Error::missing_field("yParity"))?,
+                        )
+                        .map_err(serde::de::Error::custom)?
+                        .trim_start_matches("0x"),
+                        16,
+                    )
+                    .map_err(serde::de::Error::custom)?
+                        != 0,
+                    signature_r: r,
+                    signature_s: s,
+                }),
+                TxType::EIP4844 => todo!("EIP4844 transaction deserialization"),
+            };
+            Ok(tx)
         }
     }
 

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -1100,7 +1100,9 @@ mod serde_impl {
                     signature_r: r,
                     signature_s: s,
                 }),
-                TxType::EIP4844 => todo!("EIP4844 transaction deserialization"),
+                TxType::EIP4844 => Err(serde::de::Error::custom(
+                    "EIP4844 transaction deserialization",
+                ))?,
             };
             Ok(tx)
         }

--- a/crates/storage/store/Cargo.toml
+++ b/crates/storage/store/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ethereum_rust-core.workspace = true
-ethereum_rust-trie.workspace = true
 ethereum_rust-rlp.workspace = true
+ethereum_rust-core = { path = "../../common", default-features = false }
+ethereum_rust-trie = { path = "../../storage/trie", default-features = false }
 
 ethereum-types = "0.14.1"
 anyhow = "1.0.86"
@@ -22,9 +22,13 @@ serde_json = "1.0.117"
 libmdbx = { workspace = true, optional = true }
 
 [features]
-default = ["in_memory", "libmdbx"]
+default = ["libmdbx", "in_memory"]
 in_memory = []
-libmdbx = ["dep:libmdbx"]
+libmdbx = [
+    "dep:libmdbx",
+    "ethereum_rust-trie/libmdbx",
+    "ethereum_rust-core/libmdbx",
+]
 
 [dev-dependencies]
 hex.workspace = true

--- a/crates/storage/store/Cargo.toml
+++ b/crates/storage/store/Cargo.toml
@@ -22,8 +22,7 @@ serde_json = "1.0.117"
 libmdbx = { workspace = true, optional = true }
 
 [features]
-default = ["libmdbx", "in_memory"]
-in_memory = []
+default = ["libmdbx"]
 libmdbx = [
     "dep:libmdbx",
     "ethereum_rust-trie/libmdbx",

--- a/crates/storage/store/engines.rs
+++ b/crates/storage/store/engines.rs
@@ -1,5 +1,4 @@
 pub mod api;
-#[cfg(feature = "in_memory")]
 pub mod in_memory;
 #[cfg(feature = "libmdbx")]
 pub mod libmdbx;

--- a/crates/storage/store/storage.rs
+++ b/crates/storage/store/storage.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "in_memory")]
 use self::engines::in_memory::Store as InMemoryStore;
 #[cfg(feature = "libmdbx")]
 use self::engines::libmdbx::Store as LibmdbxStore;
@@ -33,7 +32,6 @@ pub struct Store {
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 pub enum EngineType {
-    #[cfg(feature = "in_memory")]
     InMemory,
     #[cfg(feature = "libmdbx")]
     Libmdbx,
@@ -70,14 +68,13 @@ impl AccountUpdate {
 }
 
 impl Store {
-    pub fn new(path: &str, engine_type: EngineType) -> Result<Self, StoreError> {
+    pub fn new(_path: &str, engine_type: EngineType) -> Result<Self, StoreError> {
         info!("Starting storage engine ({engine_type:?})");
         let store = match engine_type {
             #[cfg(feature = "libmdbx")]
             EngineType::Libmdbx => Self {
-                engine: Arc::new(LibmdbxStore::new(path)?),
+                engine: Arc::new(LibmdbxStore::new(_path)?),
             },
-            #[cfg(feature = "in_memory")]
             EngineType::InMemory => Self {
                 engine: Arc::new(InMemoryStore::new()),
             },
@@ -715,7 +712,6 @@ mod tests {
 
     use super::*;
 
-    #[cfg(feature = "in_memory")]
     #[test]
     fn test_in_memory_store() {
         test_store_suite(EngineType::InMemory);
@@ -730,7 +726,7 @@ mod tests {
     // Creates an empty store, runs the test and then removes the store (if needed)
     fn run_test(test_func: &dyn Fn(Store), engine_type: EngineType) {
         // Remove preexistent DBs in case of a failed previous test
-        if matches!(engine_type, EngineType::Libmdbx) {
+        if !matches!(engine_type, EngineType::InMemory) {
             remove_test_dbs("store-test-db");
         };
         // Build a new store
@@ -738,7 +734,7 @@ mod tests {
         // Run the test
         test_func(store);
         // Remove store (if needed)
-        if matches!(engine_type, EngineType::Libmdbx) {
+        if !matches!(engine_type, EngineType::InMemory) {
             remove_test_dbs("store-test-db");
         };
     }

--- a/crates/storage/store/storage.rs
+++ b/crates/storage/store/storage.rs
@@ -68,12 +68,12 @@ impl AccountUpdate {
 }
 
 impl Store {
-    pub fn new(_path: &str, engine_type: EngineType) -> Result<Self, StoreError> {
+    pub fn new(path: &str, engine_type: EngineType) -> Result<Self, StoreError> {
         info!("Starting storage engine ({engine_type:?})");
         let store = match engine_type {
             #[cfg(feature = "libmdbx")]
             EngineType::Libmdbx => Self {
-                engine: Arc::new(LibmdbxStore::new(_path)?),
+                engine: Arc::new(LibmdbxStore::new(path)?),
             },
             EngineType::InMemory => Self {
                 engine: Arc::new(InMemoryStore::new()),

--- a/crates/storage/trie/Cargo.toml
+++ b/crates/storage/trie/Cargo.toml
@@ -15,20 +15,24 @@ sha3.workspace = true
 hex.workspace = true
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
-libmdbx.workspace = true
+libmdbx = { workspace = true, optional = true }
 
 # trie deps
-smallvec = {version = "1.10.0", features = ["const_generics", "union"]}
+smallvec = { version = "1.10.0", features = ["const_generics", "union"] }
 digest = "0.10.6"
 lazy_static.workspace = true
+
+[features]
+default = ["libmdbx"]
+libmdbx = ["dep:libmdbx"]
 
 [dev-dependencies]
 hex.workspace = true
 hex-literal.workspace = true
 proptest = "1.0.0"
 tempdir = "0.3.7"
-cita_trie = "4.0.0" # used for proptest comparisons
-hasher = "0.1.4" # cita_trie needs this
+cita_trie = "4.0.0"          # used for proptest comparisons
+hasher = "0.1.4"             # cita_trie needs this
 
 [lib]
 path = "./trie.rs"

--- a/crates/storage/trie/db.rs
+++ b/crates/storage/trie/db.rs
@@ -1,5 +1,7 @@
 pub mod in_memory;
+#[cfg(feature = "libmdbx")]
 pub mod libmdbx;
+#[cfg(feature = "libmdbx")]
 pub mod libmdbx_dupsort;
 
 use crate::error::TrieError;

--- a/crates/storage/trie/db/libmdbx.rs
+++ b/crates/storage/trie/db/libmdbx.rs
@@ -45,7 +45,7 @@ mod test {
     use std::sync::Arc;
 
     use super::LibmdbxTrieDB;
-    use crate::test_utils::new_db;
+    use crate::test_utils::libmdbx::new_db;
     use libmdbx::{
         orm::{table, Database},
         table_info,

--- a/crates/storage/trie/db/libmdbx_dupsort.rs
+++ b/crates/storage/trie/db/libmdbx_dupsort.rs
@@ -74,7 +74,7 @@ fn node_hash_to_fixed_size(node_hash: Vec<u8>) -> [u8; 33] {
 mod test {
 
     use super::*;
-    use crate::test_utils::new_db;
+    use crate::test_utils::libmdbx::new_db;
     use libmdbx::{dupsort, table};
 
     dupsort!(

--- a/crates/storage/trie/node_hash.rs
+++ b/crates/storage/trie/node_hash.rs
@@ -122,7 +122,6 @@ impl Encodable for NodeHash {
 }
 
 #[cfg(feature = "libmdbx")]
-
 impl Decodable for NodeHash {
     fn decode(b: &[u8]) -> anyhow::Result<Self> {
         Ok(match b.len() {

--- a/crates/storage/trie/node_hash.rs
+++ b/crates/storage/trie/node_hash.rs
@@ -1,5 +1,6 @@
 use ethereum_rust_rlp::{decode::RLPDecode, encode::RLPEncode};
 use ethereum_types::H256;
+#[cfg(feature = "libmdbx")]
 use libmdbx::orm::{Decodable, Encodable};
 use sha3::{Digest, Keccak256};
 
@@ -111,6 +112,7 @@ impl From<&NodeHash> for Vec<u8> {
     }
 }
 
+#[cfg(feature = "libmdbx")]
 impl Encodable for NodeHash {
     type Encoded = Vec<u8>;
 
@@ -118,6 +120,8 @@ impl Encodable for NodeHash {
         self.into()
     }
 }
+
+#[cfg(feature = "libmdbx")]
 
 impl Decodable for NodeHash {
     fn decode(b: &[u8]) -> anyhow::Result<Self> {

--- a/crates/storage/trie/test_utils.rs
+++ b/crates/storage/trie/test_utils.rs
@@ -1,31 +1,34 @@
-use std::{path::PathBuf, sync::Arc};
+#[cfg(feature = "libmdbx")]
+pub mod libmdbx {
+    use std::{path::PathBuf, sync::Arc};
 
-use libmdbx::{
-    orm::{table_info, Database, Table},
-    table,
-};
+    use libmdbx::{
+        orm::{table_info, Database, Table},
+        table,
+    };
 
-table!(
-    /// Test table.
-    (TestNodes) Vec<u8> => Vec<u8>
-);
+    table!(
+        /// Test table.
+        (TestNodes) Vec<u8> => Vec<u8>
+    );
 
-/// Creates a new DB on a given path
-pub fn new_db_with_path<T: Table>(path: PathBuf) -> Arc<Database> {
-    let tables = [table_info!(T)].into_iter().collect();
-    Arc::new(Database::create(Some(path), &tables).expect("Failed creating db with path"))
-}
+    /// Creates a new DB on a given path
+    pub fn new_db_with_path<T: Table>(path: PathBuf) -> Arc<Database> {
+        let tables = [table_info!(T)].into_iter().collect();
+        Arc::new(Database::create(Some(path), &tables).expect("Failed creating db with path"))
+    }
 
-/// Creates a new temporary DB
-pub fn new_db<T: Table>() -> Arc<Database> {
-    let tables = [table_info!(T)].into_iter().collect();
-    Arc::new(Database::create(None, &tables).expect("Failed to create temp DB"))
-}
+    /// Creates a new temporary DB
+    pub fn new_db<T: Table>() -> Arc<Database> {
+        let tables = [table_info!(T)].into_iter().collect();
+        Arc::new(Database::create(None, &tables).expect("Failed to create temp DB"))
+    }
 
-/// Opens a DB from a given path
-pub fn open_db<T: Table>(path: &str) -> Arc<Database> {
-    let tables = [table_info!(T)].into_iter().collect();
-    Arc::new(Database::open(path, &tables).expect("Failed to open DB"))
+    /// Opens a DB from a given path
+    pub fn open_db<T: Table>(path: &str) -> Arc<Database> {
+        let tables = [table_info!(T)].into_iter().collect();
+        Arc::new(Database::open(path, &tables).expect("Failed to open DB"))
+    }
 }
 
 #[macro_export]

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -4,27 +4,36 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ethereum_rust-core.workspace = true
-ethereum_rust-storage.workspace = true
-revm = { version = "10.0.0", features = [
+ethereum_rust-core = { path = "../common", default-features = false }
+ethereum_rust-storage = { path = "../storage/store", default-features = false }
+revm = { version = "14.0.3", features = [
     "serde",
     "std",
     "serde-json",
     "optional_no_base_fee",
     "optional_block_gas_limit",
-] }
+], default-features = false }
+
 # These dependencies must be kept up to date with the corresponding revm version, otherwise errors may pop up because of trait implementation mismatches
-revm-inspectors = { version = "0.3.1" }
-revm-primitives = { version = "6.0.0" }
+revm-inspectors = { version = "0.8.1" }
+revm-primitives = { version = "10.0.0", features = [
+    "std",
+], default-features = false }
 bytes.workspace = true
 thiserror.workspace = true
 hex.workspace = true
 lazy_static.workspace = true
 cfg-if.workspace = true
 
+serde.workspace = true
+bincode = "1"
+
 [lib]
 path = "./vm.rs"
 
 [features]
-default = []
+default = ["libmdbx", "c-kzg", "blst"]
 l2 = []
+c-kzg = ["revm/c-kzg"]
+blst = ["revm/blst"]
+libmdbx = ["ethereum_rust-storage/default", "ethereum_rust-core/libmdbx"]

--- a/crates/vm/db.rs
+++ b/crates/vm/db.rs
@@ -53,9 +53,9 @@ impl revm::Database for StoreWrapper {
             .unwrap_or_else(|| RevmU256::ZERO))
     }
 
-    fn block_hash(&mut self, number: RevmU256) -> Result<RevmB256, Self::Error> {
+    fn block_hash(&mut self, number: u64) -> Result<RevmB256, Self::Error> {
         self.store
-            .get_block_header(number.to())?
+            .get_block_header(number)?
             .map(|header| RevmB256::from_slice(&header.compute_block_hash().0))
             .ok_or_else(|| StoreError::Custom(format!("Block {number} not found")))
     }

--- a/crates/vm/mods.rs
+++ b/crates/vm/mods.rs
@@ -7,7 +7,7 @@ pub fn deduct_caller<SPEC: Spec, EXT, DB: Database>(
     context: &mut revm::Context<EXT, DB>,
 ) -> Result<(), EVMError<DB::Error>> {
     // load caller's account.
-    let (caller_account, _) = context
+    let mut caller_account = context
         .evm
         .inner
         .journaled_state
@@ -19,7 +19,10 @@ pub fn deduct_caller<SPEC: Spec, EXT, DB: Database>(
         caller_account.info.balance += context.evm.inner.env.tx.value;
     }
     // deduct gas cost from caller's account.
-    revm::handler::mainnet::deduct_caller_inner::<SPEC>(caller_account, &context.evm.inner.env);
+    revm::handler::mainnet::deduct_caller_inner::<SPEC>(
+        &mut caller_account,
+        &context.evm.inner.env,
+    );
     Ok(())
 }
 

--- a/crates/vm/vm.rs
+++ b/crates/vm/vm.rs
@@ -27,8 +27,7 @@ use revm::{
 use revm_inspectors::access_list::AccessListInspector;
 // Rename imported types for clarity
 use revm_primitives::{
-    ruint::Uint, AccessList as RevmAccessList, AccessListItem as RevmAccessListItem,
-    TxKind as RevmTxKind,
+    ruint::Uint, AccessList as RevmAccessList, AccessListItem, FixedBytes, TxKind as RevmTxKind,
 };
 // Export needed types
 pub use errors::EvmError;
@@ -174,15 +173,8 @@ pub fn create_access_list(
 
     // Run the tx with the resulting access list and estimate its gas used
     let execution_result = if execution_result.is_success() {
-        tx_env.access_list.extend(access_list.0.iter().map(|item| {
-            (
-                item.address,
-                item.storage_keys
-                    .iter()
-                    .map(|b| RevmU256::from_be_slice(b.as_slice()))
-                    .collect(),
-            )
-        }));
+        tx_env.access_list.extend(access_list.0.clone());
+
         run_without_commit(tx_env, block_env, state, spec_id)?
     } else {
         execution_result
@@ -410,7 +402,7 @@ pub fn beacon_root_contract_call(
     Ok(transaction_result.result.into())
 }
 
-fn block_env(header: &BlockHeader) -> BlockEnv {
+pub fn block_env(header: &BlockHeader) -> BlockEnv {
     BlockEnv {
         number: RevmU256::from(header.number),
         coinbase: RevmAddress(header.coinbase.0.into()),
@@ -425,7 +417,7 @@ fn block_env(header: &BlockHeader) -> BlockEnv {
     }
 }
 
-fn tx_env(tx: &Transaction) -> TxEnv {
+pub fn tx_env(tx: &Transaction) -> TxEnv {
     let mut max_fee_per_blob_gas_bytes: [u8; 32] = [0; 32];
     let max_fee_per_blob_gas = match tx.max_fee_per_blob_gas() {
         Some(x) => {
@@ -450,12 +442,16 @@ fn tx_env(tx: &Transaction) -> TxEnv {
             .access_list()
             .into_iter()
             .map(|(addr, list)| {
-                (
+                let (address, storage_keys) = (
                     RevmAddress(addr.0.into()),
                     list.into_iter()
-                        .map(|a| RevmU256::from_be_bytes(a.0))
+                        .map(|a| FixedBytes::from_slice(a.as_bytes()))
                         .collect(),
-                )
+                );
+                AccessListItem {
+                    address,
+                    storage_keys,
+                }
             })
             .collect(),
         gas_priority_fee: tx.max_priority_fee().map(RevmU256::from),
@@ -465,6 +461,9 @@ fn tx_env(tx: &Transaction) -> TxEnv {
             .map(|hash| B256::from(hash.0))
             .collect(),
         max_fee_per_blob_gas,
+        // TODO revise
+        // https://eips.ethereum.org/EIPS/eip-7702
+        authorization_list: None,
     }
 }
 
@@ -485,16 +484,20 @@ fn tx_env_from_generic(tx: &GenericTransaction, basefee: u64) -> TxEnv {
         chain_id: tx.chain_id,
         access_list: tx
             .access_list
-            .iter()
-            .map(|entry| {
-                (
-                    RevmAddress(entry.address.0.into()),
-                    entry
-                        .storage_keys
+            .clone()
+            .into_iter()
+            .map(|list| {
+                let (address, storage_keys) = (
+                    RevmAddress::from_slice(list.address.as_bytes()),
+                    list.storage_keys
                         .iter()
-                        .map(|a| RevmU256::from_be_bytes(a.0))
+                        .map(|a| FixedBytes::from_slice(a.as_bytes()))
                         .collect(),
-                )
+                );
+                AccessListItem {
+                    address,
+                    storage_keys,
+                }
             })
             .collect(),
         gas_priority_fee: tx.max_priority_fee_per_gas.map(RevmU256::from),
@@ -504,6 +507,9 @@ fn tx_env_from_generic(tx: &GenericTransaction, basefee: u64) -> TxEnv {
             .map(|hash| B256::from(hash.0))
             .collect(),
         max_fee_per_blob_gas: tx.max_fee_per_blob_gas.map(RevmU256::from),
+        // TODO revise
+        // https://eips.ethereum.org/EIPS/eip-7702
+        authorization_list: None,
     }
 }
 
@@ -514,16 +520,7 @@ fn access_list_inspector(
     spec_id: SpecId,
 ) -> Result<AccessListInspector, EvmError> {
     // Access list provided by the transaction
-    let current_access_list = RevmAccessList(
-        tx_env
-            .access_list
-            .iter()
-            .map(|(addr, list)| RevmAccessListItem {
-                address: *addr,
-                storage_keys: list.iter().map(|v| B256::from(v.to_be_bytes())).collect(),
-            })
-            .collect(),
-    );
+    let current_access_list = RevmAccessList(tx_env.access_list.clone());
     // Addresses accessed when using precompiles
     let precompile_addresses = Precompiles::new(PrecompileSpecId::from_spec_id(spec_id))
         .addresses()

--- a/crates/vm/vm.rs
+++ b/crates/vm/vm.rs
@@ -484,8 +484,7 @@ fn tx_env_from_generic(tx: &GenericTransaction, basefee: u64) -> TxEnv {
         chain_id: tx.chain_id,
         access_list: tx
             .access_list
-            .clone()
-            .into_iter()
+            .iter()
             .map(|list| {
                 let (address, storage_keys) = (
                     RevmAddress::from_slice(list.address.as_bytes()),


### PR DESCRIPTION
**Motivation**

`mdbx` cannot be compiled for the `rv32im` target (used in L2 prover) so this introduces a feature to disable it in those cases, as we need to import some `ethereum_rust` crates in the program.

This PR also adds (De)Serialization for types that we need to send to the zkVM program (which are (de)serialized in a binary format)

**Description**

- Bump up `revm` version
- Set `features` to compile limbmdbx conditionally 
- Avoid `revm's` `default-features` &rarr; https://docs.rs/crate/revm/14.0.3/features
- The `blst` feature from `revm` imported by `ethereum_rust-evm` was causing some issues, so it was disabled with `default-features = false`.
- `mdbx` is compiled conditionally based on the `libmdbx` feature.
- added CI job for building the prover zkVM program.
- adds (de)serialization for types that need to be sent to the zkVM.
