### PR TITLE
feat(l1): fixes reorg restrictions and latest valid header in engine_NewPayload

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -37,7 +37,7 @@ jobs:
             run_command:  make run-hive SIMULATION=ethereum/engine TEST_PATTERN="/Blob Transactions On Block 1, Cancun Genesis|Blob Transactions On Block 1, Shanghai Genesis|Blob Transaction Ordering, Single Account, Single Blob|Blob Transaction Ordering, Single Account, Dual Blob|Blob Transaction Ordering, Multiple Accounts|Replace Blob Transactions|Parallel Blob Transactions|ForkchoiceUpdatedV3 Modifies Payload ID on Different Beacon Root|NewPayloadV3 After Cancun|NewPayloadV3 Versioned Hashes|ForkchoiceUpdated Version on Payload Request"
           - simulation: engine-cancun
             name: "Cancun Engine tests"
-            run_command:  make run-hive SIMULATION=ethereum/engine TEST_PATTERN="cancun/Unique Payload ID|ParentHash equals BlockHash on NewPayload|Re-Execute Payload|Payload Build after New Invalid Payload|RPC|Build Payload with Invalid ChainID|Invalid PayloadAttributes, Zero timestamp, Syncing=False|Invalid PayloadAttributes, Parent timestamp, Syncing=False|Invalid PayloadAttributes, Missing BeaconRoot, Syncing=False|Suggested Fee Recipient Test|PrevRandao Opcode Transactions Test"
+            run_command:  make run-hive SIMULATION=ethereum/engine TEST_PATTERN="cancun/Unique Payload ID|ParentHash equals BlockHash on NewPayload|Re-Execute Payload|Payload Build after New Invalid Payload|RPC|Build Payload with Invalid ChainID|Invalid PayloadAttributes, Zero timestamp, Syncing=False|Invalid PayloadAttributes, Parent timestamp, Syncing=False|Invalid PayloadAttributes, Missing BeaconRoot, Syncing=False|Suggested Fee Recipient Test|PrevRandao Opcode Transactions Test|Invalid Missing Ancestor ReOrg, StateRoot"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -1,6 +1,6 @@
+use ethereum_rust_blockchain::add_block;
 use ethereum_rust_blockchain::error::ChainError;
 use ethereum_rust_blockchain::payload::build_payload;
-use ethereum_rust_blockchain::{add_block, latest_canonical_block_hash};
 use ethereum_rust_core::types::Fork;
 use ethereum_rust_core::{H256, U256};
 use ethereum_rust_storage::Store;

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -117,7 +117,7 @@ impl RpcHandler for NewPayloadV3Request {
         ))?;
 
         // NOTE: We should check if it's connected instead of future.
-        if block.header.number >= last_block_number + 1 {
+        if block.header.number > last_block_number + 1 {
             let result = PayloadStatus::syncing();
             return serde_json::to_value(result)
                 .map_err(|error| RpcErr::Internal(error.to_string()));


### PR DESCRIPTION
Changes: 

- Remove reorg restriction in the NewPayload engine api handler. Closes #893
- Puts the parent as the latest valid header for invalid blocks. Closes #911

Fixes hive tests and adds them to CI:

- Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P9
- Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=True, Invalid P9
- Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P10
- Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=True, Invalid P10
- Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P1 
- Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=True, Invalid P1