### PR TITLE
feat(levm): remove Option in gasprice

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/block.rs
+++ b/crates/vm/levm/src/opcode_handlers/block.rs
@@ -364,9 +364,8 @@ impl VM {
         if self.env.consumed_gas + gas_cost::GASPRICE > self.env.gas_limit {
             return Err(VMError::OutOfGas);
         }
-        // TODO: if not legacy or access list, then gas price is max_fee_per_gas
-        // TODO: Why do we unwrap here?
-        current_call_frame.stack.push(self.env.gas_price.unwrap())?;
+
+        current_call_frame.stack.push(self.env.gas_price)?;
 
         self.env.consumed_gas += gas_cost::GASPRICE;
 

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -171,7 +171,8 @@ pub struct Environment {
     pub prev_randao: Option<H256>,
     pub chain_id: U256,
     pub base_fee_per_gas: U256,
-    pub gas_price: Option<U256>,
+    /// this attr is gas_price or max_fee_per_gas depending on transaction type
+    pub gas_price: U256,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -212,7 +213,7 @@ impl VM {
         prev_randao: Option<H256>,
         chain_id: U256,
         base_fee_per_gas: U256,
-        gas_price: Option<U256>,
+        gas_price: U256,
         db: Db,
     ) -> Self {
         // TODO: This handles only CALL transactions.

--- a/crates/vm/levm/tests/tests.rs
+++ b/crates/vm/levm/tests/tests.rs
@@ -4088,7 +4088,7 @@ fn gasprice_op() {
         Default::default(),
         Default::default(),
         Default::default(),
-        Some(U256::from(0x9876)),
+        U256::from(0x9876),
         db,
     );
 


### PR DESCRIPTION
**Motivation**

Remove Option in gasPrice and remove the unwrap in gasPrice opcode implementation

**Description**

Removed option in gasprice attribute of environment since it's never going to be a None value (in upper layers the value is assigned with gasprice, maxfeepergas or a default)

Closes #899 
