### PR TITLE
fix(core): support data field on `GenericTransaction`

### DIFF
--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -1250,7 +1250,7 @@ mod serde_impl {
         pub gas: Option<u64>,
         #[serde(default)]
         pub value: U256,
-        #[serde(default, with = "crate::serde_utils::bytes")]
+        #[serde(default, with = "crate::serde_utils::bytes", alias = "data")]
         pub input: Bytes,
         #[serde(default, with = "crate::serde_utils::u64::hex_str")]
         pub gas_price: u64,


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Some transactions (like EIP1559) use `data` instead of `input`. As `GenericTransaction` is used for many things, like estimating gas, we should support both names.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Added an alias for `serde` deserialization so it accepts both names

<!-- Link to issues: Resolves #111, Resolves #222 -->



