### PR TITLE
feat(l2): add transaction commands

### DIFF
--- a/cmd/ethereum_rust_l2/Cargo.toml
+++ b/cmd/ethereum_rust_l2/Cargo.toml
@@ -26,6 +26,7 @@ strum = "0.26.3"
 ethereum_rust-l2.workspace = true
 ethereum_rust-core.workspace = true
 ethereum_rust-blockchain.workspace = true
+ethereum_rust-rlp.workspace = true
 libsecp256k1 = "0.7.1"
 keccak-hash = "0.10.0"
 

--- a/cmd/ethereum_rust_l2/src/cli.rs
+++ b/cmd/ethereum_rust_l2/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::{
-    commands::{autocomplete, config, stack, test, wallet},
+    commands::{autocomplete, config, stack, test, utils, wallet},
     config::load_selected_config,
 };
 use clap::{Parser, Subcommand};
@@ -23,6 +23,12 @@ enum EthereumRustL2Command {
         visible_alias = "w"
     )]
     Wallet(wallet::Command),
+    #[clap(
+        subcommand,
+        about = "Different utilities for developers.",
+        visible_alias = "u"
+    )]
+    Utils(utils::Command),
     #[clap(subcommand, about = "CLI config commands.")]
     Config(config::Command),
     #[clap(subcommand, about = "Run tests.")]
@@ -40,6 +46,7 @@ pub async fn start() -> eyre::Result<()> {
     match command {
         EthereumRustL2Command::Stack(cmd) => cmd.run(cfg).await?,
         EthereumRustL2Command::Wallet(cmd) => cmd.run(cfg).await?,
+        EthereumRustL2Command::Utils(cmd) => cmd.run().await?,
         EthereumRustL2Command::Autocomplete(cmd) => cmd.run()?,
         EthereumRustL2Command::Config(_) => unreachable!(),
         EthereumRustL2Command::Test(cmd) => cmd.run(cfg).await?,

--- a/cmd/ethereum_rust_l2/src/commands/mod.rs
+++ b/cmd/ethereum_rust_l2/src/commands/mod.rs
@@ -2,4 +2,5 @@ pub(crate) mod autocomplete;
 pub(crate) mod config;
 pub(crate) mod stack;
 pub(crate) mod test;
+pub(crate) mod utils;
 pub(crate) mod wallet;

--- a/cmd/ethereum_rust_l2/src/commands/utils.rs
+++ b/cmd/ethereum_rust_l2/src/commands/utils.rs
@@ -1,0 +1,129 @@
+use std::str::FromStr;
+
+use bytes::Bytes;
+use clap::Subcommand;
+use ethereum_types::{Address, H32, U256};
+use itertools::Itertools;
+use keccak_hash::{keccak, H256};
+
+#[derive(Subcommand)]
+pub(crate) enum Command {
+    #[clap(about = "Get ABI encode string from a function signature and arguments")]
+    Calldata {
+        #[clap(long)]
+        signature: String,
+        #[clap(long)]
+        args: String,
+    },
+}
+
+fn parse_signature(signature: &str) -> (String, Vec<String>) {
+    let sig = signature.trim().trim_start_matches("function ");
+    let (name, params) = sig.split_once('(').unwrap();
+    let params: Vec<String> = params
+        .trim_end_matches(')')
+        .split(',')
+        .map(|x| x.trim().split_once(' ').unzip().0.unwrap_or(x).to_string())
+        .collect();
+    (name.to_string(), params)
+}
+
+fn compute_function_selector(name: &str, params: Vec<String>) -> H32 {
+    let normalized_signature = format!("{name}({})", params.join(","));
+    let hash = keccak(normalized_signature.as_bytes());
+
+    H32::from(&hash[..4].try_into().unwrap())
+}
+
+fn parse_arg(arg_type: &str, arg: &str) -> Vec<u8> {
+    match arg_type {
+        "address" => {
+            let address = Address::from_str(arg).expect("Cannot parse address");
+            H256::from(address).0.to_vec()
+        }
+        "uint8" => {
+            let number = u8::from_str(arg).expect("Cannot parse number");
+            H256::from_slice(&[number]).0.to_vec()
+        }
+        "uint256" => {
+            let number = U256::from_dec_str(arg).expect("Cannot parse number");
+            let mut buf: &mut [u8] = &mut [0u8; 32];
+            number.to_big_endian(&mut buf);
+            buf.to_vec()
+        }
+        "bytes32" => {
+            let bytes = H256::from_str(arg).expect("Cannot parse bytes32");
+            bytes.0.to_vec()
+        }
+        "bytes" => {
+            let _bytes =
+                Bytes::from(hex::decode(arg.trim_start_matches("0x")).expect("Cannot parse bytes"));
+            todo!();
+        }
+        _ => {
+            panic!("Unsupported type: {arg_type}");
+        }
+    }
+}
+
+fn parse_vec_arg(arg_type: &str, arg: &str) -> Vec<u8> {
+    let args = arg.split(',');
+    match arg_type {
+        "address[]" => {
+            let mut addresses =
+                args.map(|arg| Address::from_str(arg).expect("Cannot parse address[]"));
+            println!("Encoded address: {}", addresses.join(" - "));
+        }
+        "uint8[]" => {
+            let mut numbers = args.map(|arg| u8::from_str(arg).expect("Cannot parse number[]"));
+            println!("Number: {}", numbers.join(" - "));
+        }
+        "uint256[]" => {
+            let mut numbers =
+                args.map(|arg| U256::from_dec_str(arg).expect("Cannot parse number[]"));
+            println!("Number: {}", numbers.join(" - "));
+        }
+        "bytes32[]" => {
+            let mut bytes_array =
+                args.map(|arg| H256::from_str(arg).expect("Cannot parse bytes32[]"));
+            println!("Bytes: {}", bytes_array.join(" - "));
+        }
+        _ => {
+            println!("Unsupported type: {arg_type}");
+        }
+    }
+    vec![]
+}
+
+impl Command {
+    pub async fn run(self) -> eyre::Result<()> {
+        match self {
+            Command::Calldata { signature, args } => {
+                let (name, params) = parse_signature(&signature);
+                let function_selector = compute_function_selector(&name, params.clone());
+
+                let args: Vec<&str> = args.split(' ').collect();
+
+                if params.len() != args.len() {
+                    println!(
+                        "Number of arguments does not match ({} != {})",
+                        params.len(),
+                        args.len()
+                    );
+                    return Ok(());
+                }
+
+                let mut calldata: Vec<u8> = function_selector.as_bytes().to_vec();
+                for (param, arg) in params.iter().zip(args) {
+                    if param.as_str().ends_with("[]") {
+                        calldata.extend(parse_vec_arg(param, arg));
+                    } else {
+                        calldata.extend(parse_arg(param, arg));
+                    }
+                }
+                println!("0x{}", hex::encode(calldata));
+            }
+        };
+        Ok(())
+    }
+}

--- a/cmd/ethereum_rust_l2/src/commands/wallet.rs
+++ b/cmd/ethereum_rust_l2/src/commands/wallet.rs
@@ -81,7 +81,13 @@ pub(crate) enum Command {
     Send {
         #[clap(long = "to")]
         to: Address,
-        #[clap(long = "value", value_parser = U256::from_dec_str, default_value = "0", required = false)]
+        #[clap(
+            long = "value",
+            value_parser = U256::from_dec_str,
+            default_value = "0",
+            required = false,
+            help = "Value to send in wei"
+        )]
         value: U256,
         #[clap(long = "calldata", value_parser = decode_hex, required = false, default_value = "")]
         calldata: Bytes,
@@ -114,7 +120,13 @@ pub(crate) enum Command {
             help = "If set it will do an L1 transfer, defaults to an L2 transfer"
         )]
         l1: bool,
-        #[clap(long = "value", value_parser = U256::from_dec_str, default_value = "0", required = false)]
+        #[clap(
+            long = "value",
+            value_parser = U256::from_dec_str,
+            default_value = "0",
+            required = false,
+            help = "Value to send in wei"
+        )]
         value: U256,
         #[clap(long = "from", required = false)]
         from: Option<Address>,
@@ -133,7 +145,13 @@ pub(crate) enum Command {
             help = "If set it will do an L1 transfer, defaults to an L2 transfer"
         )]
         l1: bool,
-        #[clap(long = "value", value_parser = U256::from_dec_str, default_value = "0", required = false)]
+        #[clap(
+            long = "value",
+            value_parser = U256::from_dec_str,
+            default_value = "0",
+            required = false,
+            help = "Value to send in wei"
+        )]
         value: U256,
         #[clap(long = "chain-id", required = false)]
         chain_id: Option<u64>,

--- a/cmd/ethereum_rust_l2/src/commands/wallet.rs
+++ b/cmd/ethereum_rust_l2/src/commands/wallet.rs
@@ -104,6 +104,14 @@ pub(crate) enum Command {
             help = "If set it will do an L1 transfer, defaults to an L2 transfer"
         )]
         l1: bool,
+        #[clap(long = "value", value_parser = U256::from_dec_str, default_value = "0", required = false)]
+        value: U256,
+        #[clap(long = "from", required = false)]
+        from: Option<Address>,
+        #[clap(long = "gas", required = false)]
+        gas: Option<u64>,
+        #[clap(long = "gas-price", required = false)]
+        gas_price: Option<u64>,
     },
     #[clap(about = "Deploy a contract")]
     Deploy {
@@ -276,7 +284,15 @@ impl Command {
                     if l1 { "L1" } else { "L2" }
                 );
             }
-            Command::Call { to, calldata, l1 } => {
+            Command::Call {
+                to,
+                calldata,
+                l1,
+                value,
+                from,
+                gas,
+                gas_price,
+            } => {
                 let client = match l1 {
                     true => eth_client,
                     false => rollup_client,
@@ -285,6 +301,10 @@ impl Command {
                 let call_tx = GenericTransaction {
                     to: TxKind::Call(to),
                     input: calldata,
+                    value,
+                    from: from.unwrap_or(Default::default()),
+                    max_fee_per_gas: gas,
+                    gas_price: gas_price.unwrap_or(Default::default()),
                     ..Default::default()
                 };
 

--- a/cmd/ethereum_rust_l2/src/commands/wallet.rs
+++ b/cmd/ethereum_rust_l2/src/commands/wallet.rs
@@ -359,7 +359,7 @@ impl Command {
                     input: calldata,
                     value,
                     from: from.unwrap_or(Default::default()),
-                    gas_limit,
+                    gas: gas_limit,
                     max_fee_per_gas: gas_price,
                     ..Default::default()
                 };

--- a/cmd/ethereum_rust_l2/src/commands/wallet.rs
+++ b/cmd/ethereum_rust_l2/src/commands/wallet.rs
@@ -156,7 +156,7 @@ fn decode_hex(s: &str) -> Result<Bytes, FromHexError> {
 }
 
 async fn make_eip1559_transaction(
-    client: EthClient,
+    client: &EthClient,
     to: TxKind,
     from: Address,
     data: Bytes,
@@ -318,7 +318,7 @@ impl Command {
                 };
 
                 let tx = make_eip1559_transaction(
-                    client,
+                    &client,
                     TxKind::Call(to),
                     from,
                     calldata,
@@ -385,7 +385,7 @@ impl Command {
 
                 let nonce = nonce.unwrap_or(client.get_nonce(from).await?);
                 let tx = make_eip1559_transaction(
-                    client,
+                    &client,
                     TxKind::Create,
                     from,
                     bytecode,

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -1236,7 +1236,7 @@ mod serde_impl {
 
     /// Unsigned Transaction struct generic to all types which may not contain all required transaction fields
     /// Used to perform gas estimations and access list creation
-    #[derive(Deserialize, Debug, PartialEq, Clone)]
+    #[derive(Deserialize, Debug, PartialEq, Clone, Default)]
     #[serde(rename_all = "camelCase")]
     pub struct GenericTransaction {
         #[serde(default)]

--- a/crates/l2/utils/eth_client/errors.rs
+++ b/crates/l2/utils/eth_client/errors.rs
@@ -12,6 +12,8 @@ pub enum EthClientError {
     EstimateGasPriceError(#[from] EstimateGasPriceError),
     #[error("eth_sendRawTransaction request error: {0}")]
     SendRawTransactionError(#[from] SendRawTransactionError),
+    #[error("eth_call request error: {0}")]
+    CallError(#[from] CallError),
     #[error("eth_getTransactionCount request error: {0}")]
     GetNonceError(#[from] GetNonceError),
     #[error("eth_blockNumber request error: {0}")]
@@ -52,6 +54,18 @@ pub enum EstimateGasPriceError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum SendRawTransactionError {
+    #[error("{0}")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("{0}")]
+    SerdeJSONError(#[from] serde_json::Error),
+    #[error("{0}")]
+    RPCError(String),
+    #[error("{0}")]
+    ParseIntError(#[from] std::num::ParseIntError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CallError {
     #[error("{0}")]
     ReqwestError(#[from] reqwest::Error),
     #[error("{0}")]


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
`send`, `deploy` and `call` commands are very useful commands that are always needed. `calldata` command allows to use this commands in an easier way.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Create some commands in the CLI that implement this methods, with different flags to customize the requests.

<!-- Link to issues: Resolves #111, Resolves #222 -->


