### PR TITLE
feat(levm): add transact validations

### DIFF
--- a/crates/vm/levm/src/constants.rs
+++ b/crates/vm/levm/src/constants.rs
@@ -111,11 +111,6 @@ pub const MEMORY_EXPANSION_QUOTIENT: usize = 512;
 
 // Transaction costs in gas (in wei)
 pub const TX_BASE_COST: U256 = U256([21000, 0, 0, 0]);
-pub const TX_DATA_COST_PER_NON_ZERO: u64 = 16;
-pub const TX_DATA_COST_PER_ZERO: u64 = 4;
-pub const TX_CREATE_COST: u64 = 32000;
-pub const TX_ACCESS_LIST_ADDRESS_COST: u64 = 2400;
-pub const TX_ACCESS_LIST_STORAGE_KEY_COST: u64 = 1900;
 
 pub const MAX_CODE_SIZE: usize = 0x6000;
 pub const MAX_CREATE_CODE_SIZE: usize = 2 * MAX_CODE_SIZE;

--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -12,6 +12,10 @@ pub enum VMError {
     OverflowInArithmeticOp,
     FatalError,
     InvalidTransaction,
+    SenderAccountDoesNotExist,
+    SenderAccountShouldNotHaveBytecode,
+    SenderBalanceShouldContainTransferValue,
+    GasPriceIsLowerThanBaseFee,
 }
 
 pub enum OpcodeSuccess {

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -381,8 +381,6 @@ impl VM {
 
     /// Based on ethereum yellowpaper initial tests of intrinsic validity (Section 6), which last version is
     /// Shanghai, so there are probably missing cancun validations.
-    /// Possible cancun tests:
-    /// -
     fn validate_transaction(&self) -> Result<(), VMError> {
         // Validations (1), (2), (3) and (5) are done in upper layers.
 

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -379,17 +379,17 @@ impl VM {
         }
     }
 
-    /// Based on ethereum yellowpaper initial tests of intrinsic validity (Section 6), which last version is 
+    /// Based on ethereum yellowpaper initial tests of intrinsic validity (Section 6), which last version is
     /// Shanghai, so there are probably missing cancun validations.
     /// Possible cancun tests:
-    /// - 
+    /// -
     fn validate_transaction(&self) -> Result<(), VMError> {
         // Validations (1), (2), (3) and (5) are done in upper layers.
 
         let sender_account = match self.db.accounts.get(&self.env.origin) {
             Some(acc) => acc,
-            None => return Err(VMError::SenderAccountDoesNotExist)
-        };        
+            None => return Err(VMError::SenderAccountDoesNotExist),
+        };
 
         // (4) the sender account has no contract code deployed (see EIP-3607 by Feist et al. [2021]);
         if sender_account.has_code() {


### PR DESCRIPTION
**Motivation**

This PR goal is to add validations in transact that are not done in upper layers

**Description**

The validations are based in [yellow paper's](https://ethereum.github.io/yellowpaper/paper.pdf) transaction execution section (the 6th one). At the moment there is a lack of tests of the Cancun fork.
Also, removes some constants about transactions intrinsic gas costs, because we don't do those calculations in this layer.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #900 

