### PR TITLE
fix(levm): change Makefile's lint

### DIFF
--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -9,7 +9,7 @@ test: ## 🧪 Runs all tests except Ethereum tests
 	cargo test -p ethereum_rust-levm
 
 lint: ## 🧹 Linter check
-	cargo clippy --all-targets --all-features --workspace -- -D warnings
+	cargo clippy --all-targets --all-features -- -D warnings
 
 fmt: ## 📄 Runs rustfmt
 	cargo fmt --all


### PR DESCRIPTION
**Motivation**

Change lint flag to only cover levm crate.

**Description**

This is done by removing `--workspace` flag when calling cargo clippy.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #876 

