### PR TITLE
fix(l1): add needed patch for risc0's zkVM

### DIFF
--- a/crates/storage/trie/node_hash.rs
+++ b/crates/storage/trie/node_hash.rs
@@ -189,7 +189,7 @@ impl NodeEncoder {
             l => {
                 let l_len = compute_byte_usage(l);
                 self.write_raw(&[long_base + l_len as u8]);
-                self.write_raw(&l.to_be_bytes()[size_of::<usize>() - l_len..]);
+                self.write_raw(&l.to_be_bytes()[core::mem::size_of::<usize>() - l_len..]);
             }
         }
     }


### PR DESCRIPTION
**Motivation**

We want to use [risc zero](https://risczero.com/) as proving system, we need to build ethereum_rust's crates to accomplish it.

**Description**

Replace `size_of` with `core::mem::size_of` in order to build the crate for the desired target.


