### PR TITLE
feat(l2): improve `Makefile`

### DIFF
--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -51,7 +51,7 @@ restart-contract-deps: clean-contract-deps contract-deps ## 🔄 Restarts the de
 
 deploy-l1: ## 📜 Deploys the L1 contracts
 	cd ${FOUNDRY_PROJECT_HOME} && \
-	forge script script/DeployL1.s.sol:DeployL1Script --rpc-url ${L1_RPC_URL} --private-key ${L1_PRIVATE_KEY} --broadcast
+	forge script script/DeployL1.s.sol:DeployL1Script --rpc-url ${L1_RPC_URL} --private-key ${L1_PRIVATE_KEY} --broadcast --use $$(which solc)
 
 deploy-on-chain-operator: ## 📜 Deploys the OnChainOperator contract in L1
 	forge create ${FOUNDRY_PROJECT_HOME}/src/l1/OnChainOperator.sol:OnChainOperator --rpc-url ${L1_RPC_URL} --private-key ${L1_PRIVATE_KEY}

--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -1,69 +1,70 @@
-.PHONY: init down clean init-local-l1 down-local-l1 clean-local-l1 init-l2 down-l2 deploy-l1 deploy-block-executor deploy-inbox setup-prover
+.DEFAULT_GOAL := init
+
+.PHONY: help init down clean init-local-l1 down-local-l1 clean-local-l1 init-l2 down-l2 deploy-l1 deploy-block-executor deploy-inbox setup-prover
 
 L2_GENESIS_FILE_PATH=../../test_data/genesis-l2.json
 
-init: init-local-l1 contract-deps setup-prover deploy-l1 init-l2
+help: ## 📚 Show help for each of the Makefile recipes
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-down: down-local-l1 down-l2
+init: init-local-l1 contract-deps deploy-l1 init-l2 ## 🚀 Initializes a localnet with Lambda Ethereum Rust client as both L1 and L2
 
-clean: clean-local-l1 clean-contract-deps
+down: down-local-l1 down-l2 ## 🛑 Shuts down the localnet
 
-restart: restart-local-l1 restart-contract-deps restart-l2
+clean: clean-contract-deps ## 🧹 Cleans the localnet
 
-# Contracts
+restart: restart-local-l1 restart-contract-deps restart-l2 ## 🔄 Restarts the localnet
+
+cli: ## 🛠️ Builds the L2 Lambda Ethereum Rust CLI
+	cargo build --release --manifest-path ${ETHEREUM_RUST_PATH}/cmd/ethereum_rust/Cargo.toml
+
+# Variables
+
+ETHEREUM_RUST_PATH=$(shell pwd)/../../
+ETHEREUM_RUST_BIN_PATH=$(ETHEREUM_RUST_PATH)/target/release/ethereum_rust
+ETHEREUM_RUST_DEV_DOCKER_COMPOSE_PATH=$(ETHEREUM_RUST_PATH)/crates/blockchain/dev/docker-compose-dev.yaml
 
 FOUNDRY_PROJECT_HOME=$(shell pwd)/contracts
 L1_RPC_URL=http://localhost:8545
 L1_PRIVATE_KEY=0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924
 
-contract-deps:
-	mkdir -p ${FOUNDRY_PROJECT_HOME}
-	forge install foundry-rs/forge-std --no-git --root ${FOUNDRY_PROJECT_HOME}
-	forge install succinctlabs/sp1-contracts --no-git --root ${FOUNDRY_PROJECT_HOME}
+# Local L1
 
-clean-contract-deps:
+init-local-l1: ## 🚀 Initializes an L1 Lambda Ethereum Rust Client
+	docker compose -f ${ETHEREUM_RUST_DEV_DOCKER_COMPOSE_PATH} up -d
+
+down-local-l1: ## 🛑 Shuts down the L1 Lambda Ethereum Rust Client
+	docker compose -f ${ETHEREUM_RUST_DEV_DOCKER_COMPOSE_PATH} down
+
+restart-local-l1: down-local-l1 init-local-l1 ## 🔄 Restarts the L1 Lambda Ethereum Rust Client
+
+# Contracts
+
+contract-deps: ## 📦 Installs the dependencies for the L1 contracts
+	mkdir -p ${FOUNDRY_PROJECT_HOME}
+	forge install foundry-rs/forge-std --no-git --root ${FOUNDRY_PROJECT_HOME} || exit 0
+
+clean-contract-deps: ## 🧹 Cleans the dependencies for the L1 contracts.
 	rm -rf contracts/lib
 
-restart-contract-deps: clean-contract-deps contract-deps
+restart-contract-deps: clean-contract-deps contract-deps ## 🔄 Restarts the dependencies for the L1 contracts.
 
-deploy-l1:
+deploy-l1: ## 📜 Deploys the L1 contracts
 	cd ${FOUNDRY_PROJECT_HOME} && \
 	forge script script/DeployL1.s.sol:DeployL1Script --rpc-url ${L1_RPC_URL} --private-key ${L1_PRIVATE_KEY} --broadcast
 
-deploy-block-executor:
+deploy-on-chain-operator: ## 📜 Deploys the OnChainOperator contract in L1
 	forge create ${FOUNDRY_PROJECT_HOME}/src/l1/OnChainOperator.sol:OnChainOperator --rpc-url ${L1_RPC_URL} --private-key ${L1_PRIVATE_KEY}
 
-deploy-inbox:
-	forge create ${FOUNDRY_PROJECT_HOME}/src/l1/Inbox.sol:Inbox --rpc-url ${L1_RPC_URL} --private-key ${L1_PRIVATE_KEY}
-
-# Local L1
-
-init-local-l1:
-	mkdir -p volumes/ volumes/reth volumes/reth/data
-	docker compose -f docker-compose-l2.yml up -d
-
-down-local-l1:
-	docker compose -f docker-compose-l2.yml down
-
-clean-local-l1:
-	rm -rf volumes/
-
-restart-local-l1: down-local-l1 clean-local-l1 init-local-l1
+deploy-bridge: ## 📜 Deploys the CommonBridge contract in L1
+	forge create ${FOUNDRY_PROJECT_HOME}/src/l1/CommonBridge.sol:CommonBridge --rpc-url ${L1_RPC_URL} --private-key ${L1_PRIVATE_KEY}
 
 # L2
 
-init-l2:
+init-l2: ## 🚀 Initializes an L2 Lambda Ethereum Rust Client
 	cargo run --release --manifest-path ../../Cargo.toml --bin ethereum_rust --features l2 -- --network ${L2_GENESIS_FILE_PATH} --http.port 1729 
 
-down-l2:
+down-l2: ## 🛑 Shuts down the L2 Lambda Ethereum Rust Client
 	pkill -f ethereum_rust || exit 0
 
-restart-l2: down-l2 init-l2
-
-# Prover
-
-SP1_PROGRAM_PATH=$(shell pwd)/prover/sp1/program
-
-setup-prover:
-	cd ${SP1_PROGRAM_PATH} && \
-	cargo prove build
+restart-l2: down-l2 init-l2 ## 🔄 Restarts the L2 Lambda Ethereum Rust Client

--- a/crates/l2/README.md
+++ b/crates/l2/README.md
@@ -174,41 +174,16 @@ The L2 can be initialized in Validium Mode, meaning the Data Availability layer 
 
 ## How to run
 
-### Install `ethereum_rust_l2` CLI
-
-First of all, you need to install the `ethereum_rust_l2` CLI. You can do that by running the command below at the root of this repo:
-
-```
-cargo install --path cmd/ethereum_rust_l2
-```
-
-> [!IMPORTANT]
-> Most of the CLI interaction needs a configuration to be set. You can set a configuration with the `config` command.
-
-### Configure your network
-
-> [!TIP]
-> You can create multiple configurations and switch between them.
-
-```
-ethereum_rust_l2 config create <config_name>
-```
-
-![](../../cmd/ethereum_rust_l2/assets/config_create.cast.gif)
-
 ### Initialize the network
 
 > [!IMPORTANT]
-> Before this step, make sure the Docker daemon is running.
-
-> [!IMPORTANT]
-> Add the SPI_PROVER=mock env variable to the command (to run the prover you need ).
+> Before this step:
+> 1. make sure the Docker daemon is running.
+> 2. make sure you have created a `.env` file following the `.env.example` file.
 
 ```
-ethereum_rust_l2 stack init
+make
 ```
-
-![](../../cmd/ethereum_rust_l2/assets/stack_init.cast.gif)
 
 This will setup a local Ethereum network as the L1, deploy all the needed contracts on it, then start an Ethereum Rust L2 node pointing to it.
 
@@ -218,10 +193,8 @@ This will setup a local Ethereum network as the L1, deploy all the needed contra
 > This command will cleanup your running L1 and L2 nodes.
 
 ```
-ethereum_rust_l2 stack restart
+make restart
 ```
-
-![](../../cmd/ethereum_rust_l2/assets/stack_restart.cast.gif)
 
 ## Local L1 Rich Wallets
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

To separate the localnet run from the `ethereum_rust_l2` CLI. The CLI should be used as a developer tool to improve the developer experience and for making more serious deployments (like deploying the stack on testnet).

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

- Now, to run a localnet you just need to change your current dir to the `l2` crate and run `make`.
- Adds a `help` command to the Makefile and a description for every command.

