### PR TITLE
fix(core): change `RpcRequestId` from `i32` to `u64`

### DIFF
--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -148,7 +148,7 @@ pub enum RpcNamespace {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum RpcRequestId {
-    Number(i32),
+    Number(u64),
     String(String),
 }
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Some tools like Metamask send big `u64` numbers as `id` in RPC requests that breaks the parser.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Change the `RpcRequestId::Number` type from `i32` to `u64`.

<!-- Link to issues: Resolves #111, Resolves #222 -->


