### PR TITLE
feat(l1): assertoor CI integration

### DIFF
--- a/.github/workflows/assertoor.yaml
+++ b/.github/workflows/assertoor.yaml
@@ -19,10 +19,9 @@ env:
   RUST_VERSION: 1.80.1
 
 jobs:
-  assertoor:
+  test-run:
     name: Stability Check
     runs-on: ubuntu-latest
-    needs: docker-build
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx

--- a/.github/workflows/assertoor.yaml
+++ b/.github/workflows/assertoor.yaml
@@ -1,6 +1,6 @@
-name: Assertoor Tests
-
+name: Assertoor
 on:
+  merge_group:
   push:
     branches: [ main ]
   pull_request:
@@ -10,9 +10,17 @@ on:
       - 'LICENSE'
       - "**/README.md"
       - "**/docs/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  RUST_VERSION: 1.80.1
+
 jobs:
   assertoor:
-    name: Assertoor run
+    name: Stability Check
     runs-on: ubuntu-latest
     needs: docker-build
     steps:

--- a/.github/workflows/assertoor.yaml
+++ b/.github/workflows/assertoor.yaml
@@ -1,0 +1,34 @@
+name: Assertoor Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '*' ]
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - "**/README.md"
+      - "**/docs/**"
+jobs:
+  assertoor:
+    name: Assertoor run
+    runs-on: ubuntu-latest
+    needs: docker-build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true # Important for building without pushing
+          tags: ethereum_rust
+      - name: Setup kurtosis testnet and run assertoor tests
+        uses: ethpandaops/kurtosis-assertoor-github-action@v1
+        with:
+          ethereum_package_url: 'github.com/lambdaclass/ethereum-package'
+          ethereum_package_branch: 'ethereum-rust-integration'
+          ethereum_package_args: './test_data/network_params.yaml'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,35 @@ jobs:
           context: .
           file: ./Dockerfile
           load: true # Important for building without pushing
+          tags: lambda_ethereum_rust:latest
+          outputs: type=docker,dest=/tmp/lambda_ethereum_rust.tar
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: lambda_ethereum_rust
+          path: /tmp/lambda_ethereum_rust.tar
+
+  assertoor:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: lambda_ethereum_rust
+          path: /tmp
+      - name: Load Docker image
+        run: |
+          docker load --input /tmp/lambda_ethereum_rust.tar
+          docker image ls -a
+      - name: Setup kurtosis testnet and run assertoor tests
+        uses: ethpandaops/kurtosis-assertoor-github-action@v1
+        with:
+          ethereum_package_url: 'github.com/lambdaclass/ethereum-package'
+          ethereum_package_branch: 'ethereum-rust-integration'
+          ethereum_package_args: './test_data/network_params.yaml'
 
   prover:
     name: Build RISC-V zkVM program

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: ["*"]
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - "**/README.md"
+      - "**/docs/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -75,36 +80,6 @@ jobs:
           context: .
           file: ./Dockerfile
           load: true # Important for building without pushing
-          tags: lambda_ethereum_rust:latest
-          outputs: type=docker,dest=/tmp/lambda_ethereum_rust.tar
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: lambda_ethereum_rust
-          path: /tmp/lambda_ethereum_rust.tar
-
-  assertoor:
-    name: Assertoor tests
-    runs-on: ubuntu-latest
-    needs: docker-build
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Download artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: lambda_ethereum_rust
-          path: /tmp
-      - name: Load Docker image
-        run: |
-          docker load --input /tmp/lambda_ethereum_rust.tar
-          docker image ls -a
-      - name: Setup kurtosis testnet and run assertoor tests
-        uses: ethpandaops/kurtosis-assertoor-github-action@v1
-        with:
-          ethereum_package_url: 'github.com/lambdaclass/ethereum-package'
-          ethereum_package_branch: 'ethereum-rust-integration'
-          ethereum_package_args: './test_data/network_params.yaml'
 
   prover:
     name: Build RISC-V zkVM program

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,8 +84,9 @@ jobs:
           path: /tmp/lambda_ethereum_rust.tar
 
   assertoor:
+    name: Assertoor tests
     runs-on: ubuntu-latest
-    needs: build
+    needs: docker-build
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -4,18 +4,14 @@ on:
   merge_group:
   push:
     branches: [main]
-    paths-ignore: 
-      - "crates/l2/**"
-      - 'README.md'
-      - 'LICENSE'
-      - "**/README.md"
-      - "**/docs/**"
   pull_request:
     branches: ["*"]
     paths-ignore: 
       - "crates/l2/**"
       - 'README.md'
       - 'LICENSE'
+      - "**/README.md"
+      - "**/docs/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -4,10 +4,18 @@ on:
   merge_group:
   push:
     branches: [main]
-    paths-ignore: ["crates/l2/**"]
+    paths-ignore: 
+      - "crates/l2/**"
+      - 'README.md'
+      - 'LICENSE'
+      - "**/README.md"
+      - "**/docs/**"
   pull_request:
     branches: ["*"]
-    paths-ignore: ["crates/l2/**"]
+    paths-ignore: 
+      - "crates/l2/**"
+      - 'README.md'
+      - 'LICENSE'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/test_data/el-stability-check.yml
+++ b/test_data/el-stability-check.yml
@@ -1,0 +1,19 @@
+id: el-stability-check
+name: "Check chain stability"
+timeout: 2h
+tasks:
+- name: check_clients_are_healthy
+  title: "Check if at least one client is ready"
+  timeout: 5m
+  config:
+    minClientCount: 1
+
+- name: run_tasks_concurrent
+  title: "Check if all EL & CL clients are synced"
+  timeout: 30m
+  config:
+    tasks:
+    - name: check_consensus_sync_status
+      title: "Check if CL clients are synced"
+    - name: check_execution_sync_status
+      title: "Check if EL clients are synced"

--- a/test_data/el-stability-check.yml
+++ b/test_data/el-stability-check.yml
@@ -3,7 +3,7 @@
 #
 # We removed the consensus checks to keep it minimal. The checks removed were:
 #   - check_consensus_finality
-#   - check_consensus_finality
+#   - check_consensus_attestation_stats
 #   - check_consensus_reorgs
 #   - check_consensus_forks
 

--- a/test_data/el-stability-check.yml
+++ b/test_data/el-stability-check.yml
@@ -1,5 +1,5 @@
 id: el-stability-check
-name: "Check chain stability"
+name: "Check Execution Stability"
 timeout: 2h
 tasks:
 - name: check_clients_are_healthy

--- a/test_data/el-stability-check.yml
+++ b/test_data/el-stability-check.yml
@@ -1,3 +1,12 @@
+# This file is based upon `assertoor-tests` stability check file:
+#   https://github.com/ethpandaops/assertoor-test/blob/master/assertoor-tests/stability-check.yaml
+#
+# We removed the consensus checks to keep it minimal. The checks removed were:
+#   - check_consensus_finality
+#   - check_consensus_finality
+#   - check_consensus_reorgs
+#   - check_consensus_forks
+
 id: el-stability-check
 name: "Check Execution Stability"
 timeout: 2h

--- a/test_data/network_params.yaml
+++ b/test_data/network_params.yaml
@@ -11,4 +11,8 @@ additional_services:
   - dora
 
 assertoor_params:
-  test: './test_data/el-stability-check.yml'
+  run_stability_check: false
+  run_block_proposal_check: false
+  tests:
+    - 'https://raw.githubusercontent.com/lambdaclass/lambda_ethereum_rust/refs/heads/assertoor-run-on-cd/test_data/el-stability-check.yml'
+  

--- a/test_data/network_params.yaml
+++ b/test_data/network_params.yaml
@@ -11,5 +11,4 @@ additional_services:
   - dora
 
 assertoor_params:
-  run_stability_check: true
-  run_block_proposal_check: false
+  test: './test_data/el-stability-check.yml'


### PR DESCRIPTION
**Motivation**

Assertoor integration as part of the CI

**Description**

This PR adds the [Assertoor GHA](https://github.com/ethpandaops/kurtosis-assertoor-github-action) to have a local devnet running with some checks as part of the CI. Most of the time for the stability checks was related to consensus, after removing those checks in a custom playbook created from [`stability-check.yaml`](https://github.com/ethpandaops/assertoor-test/blob/master/assertoor-tests/stability-check.yaml) we are able to run it as part of the CI. For assertoor to run with our [fork of ethereum-package](https://github.com/lambdaclass/ethereum-package) a small [commit](https://github.com/lambdaclass/ethereum-package/commit/811581ee8ab42639e4e9ef7c1197041689bfdfd1) was needed to the `ethereum-rust-integration` branch.

I've also added some entries to the `paths-ignore` on the push rules.

_Note about time: Most of the time spent in this new job is not the assertoor run, which takes ~3-5 mins, but the actual building of the docker image, which take ~9mins before starting the tests. This is done in parallel to the docker build in the CI, but now it's done 2 times. Fortunately, this is not the longest run, since `Hive / Cancun Engine tests (pull_request)` takes ~19m_

Resolves #952 

