### PR TITLE
feat(l2): get withdrawal merkle proof

### DIFF
--- a/crates/l2/utils/eth_client/errors.rs
+++ b/crates/l2/utils/eth_client/errors.rs
@@ -18,6 +18,8 @@ pub enum EthClientError {
     GetNonceError(#[from] GetNonceError),
     #[error("eth_blockNumber request error: {0}")]
     GetBlockNumberError(#[from] GetBlockNumberError),
+    #[error("eth_getBlockByHash request error: {0}")]
+    GetBlockByHashError(#[from] GetBlockByHashError),
     #[error("eth_getLogs request error: {0}")]
     GetLogsError(#[from] GetLogsError),
     #[error("eth_getTransactionReceipt request error: {0}")]
@@ -90,6 +92,18 @@ pub enum GetNonceError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum GetBlockNumberError {
+    #[error("{0}")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("{0}")]
+    SerdeJSONError(#[from] serde_json::Error),
+    #[error("{0}")]
+    RPCError(String),
+    #[error("{0}")]
+    ParseIntError(#[from] std::num::ParseIntError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GetBlockByHashError {
     #[error("{0}")]
     ReqwestError(#[from] reqwest::Error),
     #[error("{0}")]

--- a/crates/l2/utils/merkle_tree.rs
+++ b/crates/l2/utils/merkle_tree.rs
@@ -7,10 +7,42 @@ pub fn merkelize(data: Vec<H256>) -> H256 {
             .chunks(2)
             .map(|chunk| {
                 let left = chunk[0];
-                let right = if chunk.len() == 2 { chunk[1] } else { left };
-                keccak([keccak(left.0).as_bytes(), keccak(right.0).as_bytes()].concat())
+                let right = *chunk.get(1).unwrap_or(&left);
+                keccak([left.as_bytes(), right.as_bytes()].concat())
             })
             .collect();
     }
     data[0]
+}
+
+pub fn merkle_proof(data: Vec<H256>, base_element: H256) -> Option<Vec<H256>> {
+    if !data.contains(&base_element) {
+        return None;
+    }
+
+    let mut proof = vec![];
+    let mut data = data;
+
+    let mut target_hash = base_element;
+    while data.len() > 1 {
+        let current_target = target_hash;
+        data = data
+            .chunks(2)
+            .map(|chunk| {
+                let left = chunk[0];
+                let right = *chunk.get(1).unwrap_or(&left);
+                let result = keccak([left.as_bytes(), right.as_bytes()].concat());
+                if left == current_target {
+                    proof.push(right);
+                    target_hash = result;
+                } else if right == current_target {
+                    proof.push(left);
+                    target_hash = result;
+                }
+                result
+            })
+            .collect();
+    }
+
+    Some(proof)
 }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
We need a way to get the merkle path of the withdrawals so we can send them to the L1 contract.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Add a command to the CLI to get a merkle path from a tx hash

<!-- Link to issues: Resolves #111, Resolves #222 -->


