### PR TITLE
fix(l2): `help` target default when doing `make`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,12 @@ members = [
     "cmd/ethereum_rust_l2",
     "crates/vm/levm",
     "crates/vm/levm/bench/revm_comparison",
-    "crates/l2/",
     "crates/l2/prover",
 ]
 resolver = "2"
 
 exclude = ["crates/l2/contracts"]
-default-members = [
-    "cmd/ethereum_rust",
-    "cmd/ethereum_rust_l2",
-    "crates/l2/prover",
-]
+default-members = ["cmd/ethereum_rust", "cmd/ethereum_rust_l2", "crates/l2/prover"]
 
 [workspace.package]
 version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,17 @@ members = [
     "cmd/ethereum_rust_l2",
     "crates/vm/levm",
     "crates/vm/levm/bench/revm_comparison",
+    "crates/l2/",
     "crates/l2/prover",
 ]
 resolver = "2"
 
 exclude = ["crates/l2/contracts"]
-default-members = ["cmd/ethereum_rust", "cmd/ethereum_rust_l2", "crates/l2/prover"]
+default-members = [
+    "cmd/ethereum_rust",
+    "cmd/ethereum_rust_l2",
+    "crates/l2/prover",
+]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -1,4 +1,4 @@
-.DEFAULT_GOAL := init
+.DEFAULT_GOAL := help
 
 .PHONY: help init down clean init-local-l1 down-local-l1 clean-local-l1 init-l2 down-l2 deploy-l1 deploy-block-executor deploy-inbox setup-prover
 

--- a/crates/l2/README.md
+++ b/crates/l2/README.md
@@ -35,15 +35,15 @@
 
 | Milestone | Description                                                                                                                                                                                                                                                                                                       | Status |
 | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| 0         | Users can deposit Eth in the L1 (Ethereum) and receive the corresponding funds on the L2.                                                                                                                                                                                                                         | ✅      |
-| 1         | The network supports basic L2 functionality, allowing users to deposit and withdraw funds to join and exit the network, while also interacting with the network as they do normally on the Ethereum network (deploying contracts, sending transactions, etc).                                                     | 🏗️      |
-| 2         | The block execution is proven with a RISC-V zkVM and the proof is verified by the Verifier L1 contract.                                                     | 🏗️      |
-| 3         | The network now commits to state diffs instead of the full state, lowering the commit transactions costs. These diffs are also submitted in compressed form, further reducing costs. It also supports EIP 4844 for L1 commit transactions, which means state diffs are sent as blob sidecars instead of calldata. | ❌      |
-| 4         | The L2 can also be deployed using a custom native token, meaning that a certain ERC20 can be the common currency that's used for paying network fees.                                                                                                                                                             | ❌      |
-| 5         | The L2 has added security mechanisms in place, running on Trusted Execution Environments and Multi Prover setup where multiple guarantees (Execution on TEEs, zkVMs/proving systems) are required for settlement on the L1. This better protects against possible security bugs on implementations.               | ❌      |
-| 6         | The L2 supports native account abstraction following EIP 7702, allowing for custom transaction validation logic and paymaster flows.                             | ❌      |
-| 7         | The network can be run as a Based Contestable Rollup, meaning sequencing is done by the Ethereum Validator set; transactions are sent to a private mempool and L1 Validators that opt into the L2 sequencing propose blocks for the L2 on every L1 block.                                                       | ❌      |
-| 8         | The L2 can be initialized in Validium Mode, meaning the Data Availability layer is no longer the L1, but rather a DA layer of the user's choice.                             | ❌      |
+| 0         | Users can deposit Eth in the L1 (Ethereum) and receive the corresponding funds on the L2.                                                                                                                                                                                                                         | ✅     |
+| 1         | The network supports basic L2 functionality, allowing users to deposit and withdraw funds to join and exit the network, while also interacting with the network as they do normally on the Ethereum network (deploying contracts, sending transactions, etc).                                                     | 🏗️     |
+| 2         | The block execution is proven with a RISC-V zkVM and the proof is verified by the Verifier L1 contract.                                                                                                                                                                                                           | 🏗️     |
+| 3         | The network now commits to state diffs instead of the full state, lowering the commit transactions costs. These diffs are also submitted in compressed form, further reducing costs. It also supports EIP 4844 for L1 commit transactions, which means state diffs are sent as blob sidecars instead of calldata. | ❌     |
+| 4         | The L2 can also be deployed using a custom native token, meaning that a certain ERC20 can be the common currency that's used for paying network fees.                                                                                                                                                             | ❌     |
+| 5         | The L2 has added security mechanisms in place, running on Trusted Execution Environments and Multi Prover setup where multiple guarantees (Execution on TEEs, zkVMs/proving systems) are required for settlement on the L1. This better protects against possible security bugs on implementations.               | ❌     |
+| 6         | The L2 supports native account abstraction following EIP 7702, allowing for custom transaction validation logic and paymaster flows.                                                                                                                                                                              | ❌     |
+| 7         | The network can be run as a Based Contestable Rollup, meaning sequencing is done by the Ethereum Validator set; transactions are sent to a private mempool and L1 Validators that opt into the L2 sequencing propose blocks for the L2 on every L1 block.                                                         | ❌     |
+| 8         | The L2 can be initialized in Validium Mode, meaning the Data Availability layer is no longer the L1, but rather a DA layer of the user's choice.                                                                                                                                                                  | ❌     |
 
 ### Milestone 0
 
@@ -157,7 +157,7 @@ The network can be run as a Based Rollup, meaning sequencing is done by the Ethe
 
 |     | Name              | Description                                                                    | Status |
 | --- | ----------------- | ------------------------------------------------------------------------------ | ------ |
-|     | `OnChainOperator` | Add methods for proposing new blocks so the sequencing can be done from the L1 | ❌      |
+|     | `OnChainOperator` | Add methods for proposing new blocks so the sequencing can be done from the L1 | ❌     |
 
 TODO: Expand on this.
 
@@ -190,7 +190,7 @@ The L2 can be initialized in Validium Mode, meaning the Data Availability layer 
 > 2. make sure you have created a `.env` file following the `.env.example` file.
 
 ```
-make
+make init
 ```
 
 This will setup a local Ethereum network as the L1, deploy all the needed contracts on it, then start an Ethereum Rust L2 node pointing to it.


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

We want the default target to be `help` instead of `init`.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

Set `help` as default target in Makefile

