### PR TITLE
fix(l1): map the actual address when sharing bootstrap node info

### DIFF
--- a/cmd/ethereum_rust/Cargo.toml
+++ b/cmd/ethereum_rust/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1.38.0", features = ["full"] }
 anyhow = "1.0.86"
 rand = "0.8.5"
 k256 = { version = "0.13.3", features = ["ecdh"] }
+local-ip-address = "0.6"
 tokio-util.workspace = true
 
 cfg-if = "1.0.0"

--- a/test_data/network_params.yaml
+++ b/test_data/network_params.yaml
@@ -1,12 +1,12 @@
 participants:
+  - el_type: ethereumrust
+    cl_type: lighthouse
+    validator_count: 32
   - el_type: geth
     cl_type: lighthouse
     validator_count: 32
   - el_type: geth
     cl_type: prysm
-    validator_count: 32
-  - el_type: ethereumrust
-    cl_type: lighthouse
     validator_count: 32
 
 additional_services:


### PR DESCRIPTION
**Motivation**

Running in any position of the `network_params.yaml` except the last generates an error for the following node when checking our enode url

**Description**

When setting up the `Node` struct, we were using `0.0.0.0` instead of the actual ip, this PR maps `0.0.0.0` to the local ip there. 
This force us to specify the IP of the node in case of using a public one. The local IP is used due to it being the one needed in Kurtosis. If this could be an issue for other common forms of running the Node outside of the CI checks we'll need to go with a more complex solution using nat for example.

Also if we prefer to not use a crate and obtain it by ourselves I could go that path!

_Note regarding `tx_spammer`: Unfortunately `tx_spammer` is not working as we expected, being the first node in the configuration file completely removed transactions from the kurtosis run (no nodes have them now), we need to create another issue and investigate that further._

Resolves #847

