### PR TITLE
chore(l2): skip assertoor CI on l2-only changes

### DIFF
--- a/.github/workflows/assertoor.yaml
+++ b/.github/workflows/assertoor.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [ '*' ]
     paths-ignore:
+      - "crates/l2/**"
       - 'README.md'
       - 'LICENSE'
       - "**/README.md"


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Changes to crate `l2` shoudn't affect this checks, so we could avoid it

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Skip the Assertoor CI when changes are only on `crates/l2/*`

<!-- Link to issues: Resolves #111, Resolves #222 -->

