### PR TITLE
test(l1): fix updating hive revision to latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ HIVE_REVISION := ccf28e5c3e940b2bc4b4f387317ee6a46f5d15c8
 HIVE_SHALLOW_SINCE := 2024-09-02
 hive:
 	git clone --single-branch --branch master --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive
+	git checkout $(HIVE_REVISION) && go build .
 
 setup-hive: hive ## 🐝 Set up Hive testing framework
 	if [ "$$(cd hive && git rev-parse HEAD)" != "$(HIVE_REVISION)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ stop-localnet-silent:
 	@kurtosis enclave stop lambdanet >/dev/null 2>&1 || true
 	@kurtosis enclave rm lambdanet --force >/dev/null 2>&1 || true
 
-HIVE_REVISION := 3be4465a45c421651d765f4a28702962567b40e6
+HIVE_REVISION := ccf28e5c3e940b2bc4b4f387317ee6a46f5d15c8
 # Shallow clones can't specify a single revision, but at least we avoid working
 # the whole history by making it shallow since a given date (one day before our
 # target revision).

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ HIVE_REVISION := ccf28e5c3e940b2bc4b4f387317ee6a46f5d15c8
 HIVE_SHALLOW_SINCE := 2024-09-02
 hive:
 	git clone --single-branch --branch master --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive
-	git checkout --detach $(HIVE_REVISION) && go build .
+	cd hive && git checkout --detach $(HIVE_REVISION) && go build .
 
 setup-hive: hive ## 🐝 Set up Hive testing framework
 	if [ "$$(cd hive && git rev-parse HEAD)" != "$(HIVE_REVISION)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -78,13 +78,14 @@ HIVE_REVISION := ccf28e5c3e940b2bc4b4f387317ee6a46f5d15c8
 HIVE_SHALLOW_SINCE := 2024-09-02
 hive:
 	git clone --single-branch --branch master --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive
-	git checkout $(HIVE_REVISION) && go build .
+	git checkout --detach $(HIVE_REVISION) && go build .
 
 setup-hive: hive ## 🐝 Set up Hive testing framework
 	if [ "$$(cd hive && git rev-parse HEAD)" != "$(HIVE_REVISION)" ]; then \
 		cd hive && \
+		git checkout master && \
 		git fetch --shallow-since=$(HIVE_SHALLOW_SINCE) && \
-		git checkout $(HIVE_REVISION) && go build . ;\
+		git checkout --detach $(HIVE_REVISION) && go build . ;\
 	fi
 
 TEST_PATTERN ?= /


### PR DESCRIPTION
**Description**
If `HIVE_REVISION` was equal to the latest commit, the `if` in `setup-hive` would not be true and the hive command would not be executed. Let's fix it and update the hive revision to the latest commit.

