### PR TITLE
fix(l1): add temporary fix to transaction filtering & handle tx filtering unwrap edge case

### DIFF
--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -16,6 +16,8 @@ pub enum ChainError {
     StoreError(#[from] StoreError),
     #[error("EVM error: {0}")]
     EvmError(#[from] EvmError),
+    #[error("Chain error: {0}")]
+    Custom(String),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -33,7 +33,7 @@ pub enum InvalidBlockError {
     #[error("Blob gas used doesn't match value in header")]
     BlobGasUsedMismatch,
     #[error(
-        "Attempted to add and invalid transaction to the block. The transaction filter must have been failed."
+        "Attempted to add an invalid transaction to the block. The transaction filter must have failed."
     )]
     AttemptedToAddInvalidTransaction,
 }

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -16,8 +16,6 @@ pub enum ChainError {
     StoreError(#[from] StoreError),
     #[error("EVM error: {0}")]
     EvmError(#[from] EvmError),
-    #[error("Chain error: {0}")]
-    Custom(String),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -34,6 +32,10 @@ pub enum InvalidBlockError {
     GasUsedMismatch,
     #[error("Blob gas used doesn't match value in header")]
     BlobGasUsedMismatch,
+    #[error(
+        "Attempted to add and invalid transaction to the block. The transaction filter must have been failed."
+    )]
+    AttemptedToAddInvalidTransaction,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -32,10 +32,8 @@ pub enum InvalidBlockError {
     GasUsedMismatch,
     #[error("Blob gas used doesn't match value in header")]
     BlobGasUsedMismatch,
-    #[error(
-        "Attempted to add an invalid transaction to the block. The transaction filter must have failed."
-    )]
-    AttemptedToAddInvalidTransaction,
+    #[error("Invalid transaction: {0}")]
+    InvalidTransaction(String),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -16,6 +16,7 @@ use ethereum_rust_core::{
     Address, H256, U256,
 };
 use ethereum_rust_storage::{error::StoreError, Store};
+use tracing::warn;
 
 /// Add a blob transaction and its blobs bundle to the mempool
 pub fn add_blob_transaction(
@@ -84,7 +85,6 @@ pub fn filter_transactions(
         // This should be removed once https://github.com/lambdaclass/ethereum_rust/issues/680
         // is addressed.
         if tx.effective_gas_tip(filter.base_fee).is_none() {
-            println!("Invalid transaction: {:?}", tx);
             return false;
         }
 

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -80,13 +80,6 @@ pub fn filter_transactions(
             return false;
         }
 
-        // This is a temporary fix to avoid invalid transactions to be included.
-        // This should be removed once https://github.com/lambdaclass/ethereum_rust/issues/680
-        // is addressed.
-        if tx.effective_gas_tip(filter.base_fee).is_none() {
-            return false;
-        }
-
         // Filter by tip & base_fee
         if let Some(min_tip) = filter.min_tip {
             if !tx
@@ -95,7 +88,13 @@ pub fn filter_transactions(
             {
                 return false;
             }
+        // This is a temporary fix to avoid invalid transactions to be included.
+        // This should be removed once https://github.com/lambdaclass/ethereum_rust/issues/680
+        // is addressed.
+        } else if tx.effective_gas_tip(filter.base_fee).is_none() {
+            return false;
         }
+
         // Filter by blob gas fee
         if let (true, Some(blob_fee)) = (is_blob_tx, filter.blob_fee) {
             if !tx.max_fee_per_blob_gas().is_some_and(|fee| fee >= blob_fee) {

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -81,10 +81,7 @@ pub fn filter_transactions(
         }
         // Filter by tip & base_fee
         if let Some(min_tip) = filter.min_tip {
-            if !tx
-                .effective_gas_tip(filter.base_fee)
-                .is_some_and(|tip| tip >= min_tip)
-            {
+            if !tx.effective_gas_tip(filter.base_fee) >= min_tip {
                 return false;
             }
         }

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -16,7 +16,6 @@ use ethereum_rust_core::{
     Address, H256, U256,
 };
 use ethereum_rust_storage::{error::StoreError, Store};
-use tracing::warn;
 
 /// Add a blob transaction and its blobs bundle to the mempool
 pub fn add_blob_transaction(

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -81,7 +81,10 @@ pub fn filter_transactions(
         }
         // Filter by tip & base_fee
         if let Some(min_tip) = filter.min_tip {
-            if !tx.effective_gas_tip(filter.base_fee) >= min_tip {
+            if !tx
+                .effective_gas_tip(filter.base_fee)
+                .is_some_and(|tip| tip >= min_tip)
+            {
                 return false;
             }
         }

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -81,7 +81,7 @@ pub fn filter_transactions(
         }
         // Filter by tip & base_fee
         if let Some(min_tip) = filter.min_tip {
-            if !tx.effective_gas_tip(filter.base_fee) >= min_tip {
+            if tx.effective_gas_tip(filter.base_fee) < min_tip {
                 return false;
             }
         }

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -79,6 +79,15 @@ pub fn filter_transactions(
         if filter.only_plain_txs && is_blob_tx || filter.only_blob_txs && !is_blob_tx {
             return false;
         }
+
+        // This is a temporary fix to avoid invalid transactions to be included.
+        // This should be removed once https://github.com/lambdaclass/ethereum_rust/issues/680
+        // is addressed.
+        if tx.effective_gas_tip(filter.base_fee).is_none() {
+            println!("Invalid transaction: {:?}", tx);
+            return false;
+        }
+
         // Filter by tip & base_fee
         if let Some(min_tip) = filter.min_tip {
             if !tx

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -81,7 +81,7 @@ pub fn filter_transactions(
         }
         // Filter by tip & base_fee
         if let Some(min_tip) = filter.min_tip {
-            if tx.effective_gas_tip(filter.base_fee) < min_tip {
+            if !tx.effective_gas_tip(filter.base_fee) >= min_tip {
                 return false;
             }
         }

--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -446,7 +446,8 @@ impl TransactionQueue {
             // This should be a newly filtered tx list so we are guaranteed to have a first element
             let head_tx = txs.remove(0);
             heads.push(HeadTransaction {
-                tip: head_tx.effective_gas_tip(base_fee),
+                // We already ran this method when filtering the transactions from the mempool so it shouldn't fail
+                tip: head_tx.effective_gas_tip(base_fee).unwrap(),
                 tx: head_tx,
                 sender: *address,
             });
@@ -494,7 +495,8 @@ impl TransactionQueue {
             if !txs.is_empty() {
                 let head_tx = txs.remove(0);
                 let head = HeadTransaction {
-                    tip: head_tx.effective_gas_tip(self.base_fee),
+                    // We already ran this method when filtering the transactions from the mempool so it shouldn't fail
+                    tip: head_tx.effective_gas_tip(self.base_fee).unwrap(),
                     tx: head_tx,
                     sender: tx.sender,
                 };

--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -446,8 +446,7 @@ impl TransactionQueue {
             // This should be a newly filtered tx list so we are guaranteed to have a first element
             let head_tx = txs.remove(0);
             heads.push(HeadTransaction {
-                // We already ran this method when filtering the transactions from the mempool so it shouldn't fail
-                tip: head_tx.effective_gas_tip(base_fee).unwrap(),
+                tip: head_tx.effective_gas_tip(base_fee),
                 tx: head_tx,
                 sender: *address,
             });
@@ -495,8 +494,7 @@ impl TransactionQueue {
             if !txs.is_empty() {
                 let head_tx = txs.remove(0);
                 let head = HeadTransaction {
-                    // We already ran this method when filtering the transactions from the mempool so it shouldn't fail
-                    tip: head_tx.effective_gas_tip(self.base_fee).unwrap(),
+                    tip: head_tx.effective_gas_tip(self.base_fee),
                     tx: head_tx,
                     sender: tx.sender,
                 };

--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -25,7 +25,7 @@ use crate::{
         GAS_LIMIT_BOUND_DIVISOR, GAS_PER_BLOB, MAX_BLOB_GAS_PER_BLOCK, MIN_GAS_LIMIT,
         TARGET_BLOB_GAS_PER_BLOCK, TX_GAS_COST,
     },
-    error::ChainError,
+    error::{ChainError, InvalidBlockError},
     mempool::{self, PendingTxFilter},
 };
 
@@ -450,7 +450,11 @@ impl TransactionQueue {
             let head_tx = txs.remove(0);
             heads.push(HeadTransaction {
                 // We already ran this method when filtering the transactions from the mempool so it shouldn't fail
-                tip: head_tx.effective_gas_tip(base_fee).ok_or(ChainError::Custom("Attempted to add and invalid transaction to the block. The transaction filter must have been failed.".to_owned()))?,
+                tip: head_tx
+                    .effective_gas_tip(base_fee)
+                    .ok_or(ChainError::InvalidBlock(
+                        InvalidBlockError::AttemptedToAddInvalidTransaction,
+                    ))?,
                 tx: head_tx,
                 sender: *address,
             });
@@ -499,7 +503,11 @@ impl TransactionQueue {
                 let head_tx = txs.remove(0);
                 let head = HeadTransaction {
                     // We already ran this method when filtering the transactions from the mempool so it shouldn't fail
-                    tip: head_tx.effective_gas_tip(self.base_fee).ok_or(ChainError::Custom("Attempted to add and invalid transaction to the block. The transaction filter must have been failed.".to_owned()))?,
+                    tip: head_tx.effective_gas_tip(self.base_fee).ok_or(
+                        ChainError::InvalidBlock(
+                            InvalidBlockError::AttemptedToAddInvalidTransaction,
+                        ),
+                    )?,
                     tx: head_tx,
                     sender: tx.sender,
                 };

--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -453,7 +453,7 @@ impl TransactionQueue {
                 tip: head_tx
                     .effective_gas_tip(base_fee)
                     .ok_or(ChainError::InvalidBlock(
-                        InvalidBlockError::AttemptedToAddInvalidTransaction,
+                        InvalidBlockError::InvalidTransaction("Attempted to add an invalid transaction to the block. The transaction filter must have failed.".to_owned()),
                     ))?,
                 tx: head_tx,
                 sender: *address,
@@ -505,7 +505,7 @@ impl TransactionQueue {
                     // We already ran this method when filtering the transactions from the mempool so it shouldn't fail
                     tip: head_tx.effective_gas_tip(self.base_fee).ok_or(
                         ChainError::InvalidBlock(
-                            InvalidBlockError::AttemptedToAddInvalidTransaction,
+                            InvalidBlockError::InvalidTransaction("Attempted to add an invalid transaction to the block. The transaction filter must have failed.".to_owned()),
                         ),
                     )?,
                     tx: head_tx,

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -760,13 +760,12 @@ impl Transaction {
         self.max_fee_per_gas().unwrap_or(self.gas_price())
     }
 
-    pub fn effective_gas_tip(&self, base_fee: Option<u64>) -> Option<u64> {
+    pub fn effective_gas_tip(&self, base_fee: Option<u64>) -> u64 {
         let Some(base_fee) = base_fee else {
-            return Some(self.gas_tip_cap());
+            return self.gas_tip_cap();
         };
-        self.gas_fee_cap()
-            .checked_sub(base_fee)
-            .map(|tip| min(tip, self.gas_tip_cap()))
+        let tip = self.gas_fee_cap().saturating_sub(base_fee);
+        min(tip, self.gas_tip_cap())
     }
 
     /// Returns whether the transaction is replay-protected.

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -760,12 +760,13 @@ impl Transaction {
         self.max_fee_per_gas().unwrap_or(self.gas_price())
     }
 
-    pub fn effective_gas_tip(&self, base_fee: Option<u64>) -> u64 {
+    pub fn effective_gas_tip(&self, base_fee: Option<u64>) -> Option<u64> {
         let Some(base_fee) = base_fee else {
-            return self.gas_tip_cap();
+            return Some(self.gas_tip_cap());
         };
-        let tip = self.gas_fee_cap().saturating_sub(base_fee);
-        min(tip, self.gas_tip_cap())
+        self.gas_fee_cap()
+            .checked_sub(base_fee)
+            .map(|tip| min(tip, self.gas_tip_cap()))
     }
 
     /// Returns whether the transaction is replay-protected.


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

To avoid panicking when the transaction filter fails to filter a transaction because we do not yet filter transactions with invalid tip.

**Description**

- Filter transactions whose effective gas tip calculation underflowed.
- Handle the unwrap of the `effective_gas_tip` calculation. Even though this is an edge case that shouldn't happen, it is better to have a descriptive error if it happens someday than to panic.

