### PR TITLE
fix(l1): fix kurtosis version to the latest working: 1.3.1

### DIFF
--- a/.github/workflows/assertoor.yaml
+++ b/.github/workflows/assertoor.yaml
@@ -37,6 +37,7 @@ jobs:
       - name: Setup kurtosis testnet and run assertoor tests
         uses: ethpandaops/kurtosis-assertoor-github-action@v1
         with:
+          kurtosis_version: '1.3.1'
           ethereum_package_url: 'github.com/lambdaclass/ethereum-package'
           ethereum_package_branch: 'ethereum-rust-integration'
           ethereum_package_args: './test_data/network_params.yaml'


### PR DESCRIPTION
**Motivation**

Kurtosis moved from 1.3.1 to 1.4.0 and our checks started failing when loading the kurtosis engine
**Description**

This PR fixes kurtosis version to the latest working one: 1.3.1