### PR TITLE
feat(l1): compute block hash once

### DIFF
--- a/cmd/ef_tests/test_runner.rs
+++ b/cmd/ef_tests/test_runner.rs
@@ -30,7 +30,7 @@ pub fn run_ef_test(test_key: &str, test: &TestUnit) {
 
         // Won't panic because test has been validated
         let block: &CoreBlock = &block_fixture.block().unwrap().clone().into();
-        let hash = block.header.compute_block_hash();
+        let hash = block.hash();
 
         // Attempt to add the block as the head of the chain
         let chain_result = add_block(block, &store);

--- a/cmd/ef_tests/types.rs
+++ b/cmd/ef_tests/types.rs
@@ -175,14 +175,14 @@ impl BlockWithRLP {
 }
 impl From<Block> for CoreBlock {
     fn from(val: Block) -> Self {
-        Self {
-            header: val.block_header.into(),
-            body: BlockBody {
+        CoreBlock::new(
+            val.block_header.into(),
+            BlockBody {
                 transactions: val.transactions.iter().map(|t| t.clone().into()).collect(),
                 ommers: val.uncle_headers.iter().map(|h| h.clone().into()).collect(),
                 withdrawals: val.withdrawals,
             },
-        }
+        )
     }
 }
 

--- a/cmd/ethereum_rust/decode.rs
+++ b/cmd/ethereum_rust/decode.rs
@@ -56,19 +56,19 @@ mod tests {
         assert_eq!(
             H256::from_str("0xac5c61edb087a51279674fe01d5c1f65eac3fd8597f9bea215058e745df8088e")
                 .unwrap(),
-            blocks.first().unwrap().header.compute_block_hash(),
+            blocks.first().unwrap().hash(),
             "First block hash does not match"
         );
         assert_eq!(
             H256::from_str("0xa111ce2477e1dd45173ba93cac819e62947e62a63a7d561b6f4825fb31c22645")
                 .unwrap(),
-            blocks.get(1).unwrap().header.compute_block_hash(),
+            blocks.get(1).unwrap().hash(),
             "Second block hash does not match"
         );
         assert_eq!(
             H256::from_str("0x8f64c4436f7213cfdf02cfb9f45d012f1774dfb329b8803de5e7479b11586902")
                 .unwrap(),
-            blocks.get(19).unwrap().header.compute_block_hash(),
+            blocks.get(19).unwrap().hash(),
             "Last block hash does not match"
         );
     }

--- a/cmd/ethereum_rust/ethereum_rust.rs
+++ b/cmd/ethereum_rust/ethereum_rust.rs
@@ -125,7 +125,7 @@ async fn main() {
         let blocks = read_chain_file(chain_rlp_path);
         let size = blocks.len();
         for block in &blocks {
-            let hash = block.header.compute_block_hash();
+            let hash = block.hash();
             info!(
                 "Adding block {} with hash {:#x}.",
                 block.header.number, hash
@@ -139,7 +139,7 @@ async fn main() {
             }
         }
         if let Some(last_block) = blocks.last() {
-            let hash = last_block.header.compute_block_hash();
+            let hash = last_block.hash();
             apply_fork_choice(&store, hash, hash, hash).unwrap();
         }
         info!("Added {} blocks to blockchain", size);

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -52,7 +52,7 @@ pub fn add_block(block: &Block, storage: &Store) -> Result<(), ChainError> {
     // Check state root matches the one in block header after execution
     validate_state_root(&block.header, new_state_root)?;
 
-    let block_hash = block.header.compute_block_hash();
+    let block_hash = block.hash();
     store_block(storage, block.clone())?;
     store_receipts(storage, receipts, block_hash)?;
 

--- a/crates/blockchain/smoke_test.rs
+++ b/crates/blockchain/smoke_test.rs
@@ -25,7 +25,7 @@ mod test {
 
         // Add first block. We'll make it canonical.
         let block_1a = new_block(&store, &genesis_header);
-        let hash_1a = block_1a.header.compute_block_hash();
+        let hash_1a = block_1a.hash();
         add_block(&block_1a, &store).unwrap();
         store.set_canonical_block(1, hash_1a).unwrap();
         let retrieved_1a = store.get_block_header(1).unwrap().unwrap();
@@ -35,7 +35,7 @@ mod test {
 
         // Add second block at height 1. Will not be canonical.
         let block_1b = new_block(&store, &genesis_header);
-        let hash_1b = block_1b.header.compute_block_hash();
+        let hash_1b = block_1b.hash();
         add_block(&block_1b, &store).expect("Could not add block 1b.");
         let retrieved_1b = store.get_block_header_by_hash(hash_1b).unwrap().unwrap();
 
@@ -44,7 +44,7 @@ mod test {
 
         // Add a third block at height 2, child to the non canonical block.
         let block_2 = new_block(&store, &block_1b.header);
-        let hash_2 = block_2.header.compute_block_hash();
+        let hash_2 = block_2.hash();
         add_block(&block_2, &store).expect("Could not add block 2.");
         let retrieved_2 = store.get_block_header_by_hash(hash_2).unwrap();
 
@@ -54,7 +54,7 @@ mod test {
         // Receive block 2 as new head.
         apply_fork_choice(
             &store,
-            block_2.header.compute_block_hash(),
+            block_2.hash(),
             genesis_header.compute_block_hash(),
             genesis_header.compute_block_hash(),
         )
@@ -76,7 +76,7 @@ mod test {
 
         // Add first block. Not canonical.
         let block_1a = new_block(&store, &genesis_header);
-        let hash_1a = block_1a.header.compute_block_hash();
+        let hash_1a = block_1a.hash();
         add_block(&block_1a, &store).unwrap();
         let retrieved_1a = store.get_block_header_by_hash(hash_1a).unwrap().unwrap();
 
@@ -84,7 +84,7 @@ mod test {
 
         // Add second block at height 1. Canonical.
         let block_1b = new_block(&store, &genesis_header);
-        let hash_1b = block_1b.header.compute_block_hash();
+        let hash_1b = block_1b.hash();
         add_block(&block_1b, &store).expect("Could not add block 1b.");
         apply_fork_choice(&store, hash_1b, genesis_hash, genesis_hash).unwrap();
         let retrieved_1b = store.get_block_header(1).unwrap().unwrap();
@@ -96,7 +96,7 @@ mod test {
 
         // Add a third block at height 2, child to the canonical one.
         let block_2 = new_block(&store, &block_1b.header);
-        let hash_2 = block_2.header.compute_block_hash();
+        let hash_2 = block_2.hash();
         add_block(&block_2, &store).expect("Could not add block 2.");
         apply_fork_choice(&store, hash_2, genesis_hash, genesis_hash).unwrap();
         let retrieved_2 = store.get_block_header_by_hash(hash_2).unwrap();
@@ -109,7 +109,7 @@ mod test {
         // Receive block 1a as new head.
         apply_fork_choice(
             &store,
-            block_1a.header.compute_block_hash(),
+            block_1a.hash(),
             genesis_header.compute_block_hash(),
             genesis_header.compute_block_hash(),
         )
@@ -131,12 +131,12 @@ mod test {
 
         // Add block at height 1.
         let block_1 = new_block(&store, &genesis_header);
-        let hash_1 = block_1.header.compute_block_hash();
+        let hash_1 = block_1.hash();
         add_block(&block_1, &store).expect("Could not add block 1b.");
 
         // Add child at height 2.
         let block_2 = new_block(&store, &block_1.header);
-        let hash_2 = block_2.header.compute_block_hash();
+        let hash_2 = block_2.hash();
         add_block(&block_2, &store).expect("Could not add block 2.");
 
         assert!(!is_canonical(&store, 1, hash_1).unwrap());
@@ -177,7 +177,7 @@ mod test {
 
         // Add child at height 2.
         let block_2 = new_block(&store, &block_1.header);
-        let hash_2 = block_2.header.compute_block_hash();
+        let hash_2 = block_2.hash();
         add_block(&block_2, &store).expect("Could not add block 2.");
 
         assert_eq!(latest_canonical_block_hash(&store).unwrap(), genesis_hash);
@@ -189,7 +189,7 @@ mod test {
 
         // Add a new, non canonical block, starting from genesis.
         let block_1b = new_block(&store, &genesis_header);
-        let hash_b = block_1b.header.compute_block_hash();
+        let hash_b = block_1b.hash();
         add_block(&block_1b, &store).expect("Could not add block b.");
 
         // The latest block should be the same.

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -20,6 +20,7 @@ secp256k1 = { version = "0.29", default-features = false, features = [
     "global-context",
     "recovery",
 ] }
+once_cell = "1.20.2"
 crc32fast.workspace = true
 bytes.workspace = true
 hex.workspace = true

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -171,9 +171,7 @@ pub struct GenesisAccount {
 
 impl Genesis {
     pub fn get_block(&self) -> Block {
-        let header = self.get_block_header();
-        let body = self.get_block_body();
-        Block { header, body }
+        Block::new(self.get_block_header(), self.get_block_body())
     }
 
     fn get_block_header(&self) -> BlockHeader {
@@ -379,7 +377,7 @@ mod tests {
         let reader = BufReader::new(file);
         let genesis: Genesis =
             serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
-        let genesis_block_hash = genesis.get_block().header.compute_block_hash();
+        let genesis_block_hash = genesis.get_block().hash();
         assert_eq!(
             genesis_block_hash,
             H256::from_str("0xcb5306dd861d0f2c1f9952fbfbc75a46d0b6ce4f37bea370c3471fe8410bf40b")
@@ -403,7 +401,7 @@ mod tests {
         let reader = BufReader::new(file);
         let genesis: Genesis =
             serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
-        let computed_block_hash = genesis.get_block().header.compute_block_hash();
+        let computed_block_hash = genesis.get_block().hash();
         let genesis_block_hash =
             H256::from_str("0x30f516e34fc173bb5fc4daddcc7532c4aca10b702c7228f3c806b4df2646fb7e")
                 .unwrap();

--- a/crates/l2/proposer/mod.rs
+++ b/crates/l2/proposer/mod.rs
@@ -155,7 +155,7 @@ impl Proposer {
             };
 
             let new_state_root_hash = store
-                .state_trie(block.header.compute_block_hash())
+                .state_trie(block.hash())
                 .unwrap()
                 .unwrap()
                 .hash()

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -83,7 +83,7 @@ impl RpcHandler for NewPayloadV3Request {
         }
 
         // Check that block_hash is valid
-        let actual_block_hash = block.header.compute_block_hash();
+        let actual_block_hash = block.hash();
         if block_hash != actual_block_hash {
             let result = PayloadStatus::invalid_with_err("Invalid block hash");
             return serde_json::to_value(result)

--- a/crates/networking/rpc/eth/block.rs
+++ b/crates/networking/rpc/eth/block.rs
@@ -258,7 +258,7 @@ impl RpcHandler for GetRawBlockRequest {
             (Some(header), Some(body)) => (header, body),
             _ => return Ok(Value::Null),
         };
-        let block = Block { header, body }.encode_to_vec();
+        let block = Block::new(header, body).encode_to_vec();
 
         serde_json::to_value(format!("0x{}", &hex::encode(block)))
             .map_err(|error| RpcErr::Internal(error.to_string()))

--- a/crates/networking/rpc/eth/fee_market.rs
+++ b/crates/networking/rpc/eth/fee_market.rs
@@ -110,7 +110,7 @@ impl RpcHandler for FeeHistoryRequest {
             );
 
             if let Some(percentiles) = &self.reward_percentiles {
-                let block = Block { header, body };
+                let block = Block::new(header, body);
                 reward.push(Self::calculate_percentiles_for_block(block, percentiles));
             }
         }

--- a/crates/networking/rpc/eth/gas_price.rs
+++ b/crates/networking/rpc/eth/gas_price.rs
@@ -211,10 +211,7 @@ mod tests {
                 withdrawals: Default::default(),
             };
             let block_header = test_header(block_num);
-            let block = Block {
-                body: block_body,
-                header: block_header.clone(),
-            };
+            let block = Block::new(block_header.clone(), block_body);
             store.add_block(block).unwrap();
             store
                 .set_canonical_block(block_num, block_header.compute_block_hash())
@@ -241,10 +238,7 @@ mod tests {
                 withdrawals: Default::default(),
             };
             let block_header = test_header(block_num);
-            let block = Block {
-                body: block_body,
-                header: block_header.clone(),
-            };
+            let block = Block::new(block_header.clone(), block_body);
             store.add_block(block).unwrap();
             store
                 .set_canonical_block(block_num, block_header.compute_block_hash())
@@ -272,10 +266,7 @@ mod tests {
                 withdrawals: Default::default(),
             };
             let block_header = test_header(block_num);
-            let block = Block {
-                body: block_body,
-                header: block_header.clone(),
-            };
+            let block = Block::new(block_header.clone(), block_body);
             store.add_block(block).unwrap();
             store
                 .set_canonical_block(block_num, block_header.compute_block_hash())
@@ -298,10 +289,7 @@ mod tests {
                 withdrawals: Default::default(),
             };
             let block_header = test_header(block_num);
-            let block = Block {
-                body: block_body,
-                header: block_header.clone(),
-            };
+            let block = Block::new(block_header.clone(), block_body);
             store.add_block(block).unwrap();
             store
                 .set_canonical_block(block_num, block_header.compute_block_hash())
@@ -342,10 +330,7 @@ mod tests {
                 withdrawals: Default::default(),
             };
             let block_header = test_header(block_num);
-            let block = Block {
-                body: block_body,
-                header: block_header.clone(),
-            };
+            let block = Block::new(block_header.clone(), block_body);
             storage.add_block(block).unwrap();
             storage
                 .set_canonical_block(block_num, block_header.compute_block_hash())

--- a/crates/networking/rpc/types/block.rs
+++ b/crates/networking/rpc/types/block.rs
@@ -52,12 +52,9 @@ impl RpcBlock {
         full_transactions: bool,
         total_difficulty: U256,
     ) -> RpcBlock {
-        let size = Block {
-            header: header.clone(),
-            body: body.clone(),
-        }
-        .encode_to_vec()
-        .len();
+        let size = Block::new(header.clone(), body.clone())
+            .encode_to_vec()
+            .len();
         let body_wrapper = if full_transactions {
             BlockBodyWrapper::Full(FullBlockBody::from_body(body, header.number, hash))
         } else {

--- a/crates/networking/rpc/types/payload.rs
+++ b/crates/networking/rpc/types/payload.rs
@@ -91,33 +91,33 @@ impl ExecutionPayloadV3 {
             ommers: vec![],
             withdrawals: Some(self.withdrawals),
         };
-        Ok(Block {
-            header: BlockHeader {
-                parent_hash: self.parent_hash,
-                ommers_hash: *DEFAULT_OMMERS_HASH,
-                coinbase: self.fee_recipient,
-                state_root: self.state_root,
-                transactions_root: compute_transactions_root(&body.transactions),
-                receipts_root: self.receipts_root,
-                logs_bloom: self.logs_bloom,
-                difficulty: 0.into(),
-                number: self.block_number,
-                gas_limit: self.gas_limit,
-                gas_used: self.gas_used,
-                timestamp: self.timestamp,
-                extra_data: self.extra_data,
-                prev_randao: self.prev_randao,
-                nonce: 0,
-                base_fee_per_gas: Some(self.base_fee_per_gas),
-                withdrawals_root: Some(compute_withdrawals_root(
-                    &body.withdrawals.clone().unwrap_or_default(),
-                )),
-                blob_gas_used: Some(self.blob_gas_used),
-                excess_blob_gas: Some(self.excess_blob_gas),
-                parent_beacon_block_root: Some(parent_beacon_block_root),
-            },
-            body,
-        })
+
+        let header = BlockHeader {
+            parent_hash: self.parent_hash,
+            ommers_hash: *DEFAULT_OMMERS_HASH,
+            coinbase: self.fee_recipient,
+            state_root: self.state_root,
+            transactions_root: compute_transactions_root(&body.transactions),
+            receipts_root: self.receipts_root,
+            logs_bloom: self.logs_bloom,
+            difficulty: 0.into(),
+            number: self.block_number,
+            gas_limit: self.gas_limit,
+            gas_used: self.gas_used,
+            timestamp: self.timestamp,
+            extra_data: self.extra_data,
+            prev_randao: self.prev_randao,
+            nonce: 0,
+            base_fee_per_gas: Some(self.base_fee_per_gas),
+            withdrawals_root: Some(compute_withdrawals_root(
+                &body.withdrawals.clone().unwrap_or_default(),
+            )),
+            blob_gas_used: Some(self.blob_gas_used),
+            excess_blob_gas: Some(self.excess_blob_gas),
+            parent_beacon_block_root: Some(parent_beacon_block_root),
+        };
+
+        Ok(Block::new(header, body))
     }
 
     pub fn from_block(block: Block) -> Self {
@@ -134,7 +134,7 @@ impl ExecutionPayloadV3 {
             timestamp: block.header.timestamp,
             extra_data: block.header.extra_data.clone(),
             base_fee_per_gas: block.header.base_fee_per_gas.unwrap_or_default(),
-            block_hash: block.header.compute_block_hash(),
+            block_hash: block.hash(),
             transactions: block
                 .body
                 .transactions

--- a/crates/storage/store/engines/api.rs
+++ b/crates/storage/store/engines/api.rs
@@ -172,7 +172,7 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
             Some(body) => body,
             None => return Ok(None),
         };
-        Ok(Some(Block { header, body }))
+        Ok(Some(Block::new(header, body)))
     }
 
     // Get the canonical block hash for a given block number.

--- a/crates/storage/store/engines/libmdbx.rs
+++ b/crates/storage/store/engines/libmdbx.rs
@@ -466,7 +466,7 @@ impl StoreEngine for Store {
             Some(body) => body,
             None => return Ok(None),
         };
-        Ok(Some(Block { header, body }))
+        Ok(Some(Block::new(header, body)))
     }
 
     fn unset_canonical_block(&self, number: BlockNumber) -> Result<(), StoreError> {

--- a/crates/storage/store/storage.rs
+++ b/crates/storage/store/storage.rs
@@ -443,7 +443,7 @@ impl Store {
         let genesis_block = genesis.get_block();
         let genesis_block_number = genesis_block.header.number;
 
-        let genesis_hash = genesis_block.header.compute_block_hash();
+        let genesis_hash = genesis_block.hash();
 
         if let Some(header) = self.get_block_header(genesis_block_number)? {
             if header.compute_block_hash() == genesis_hash {


### PR DESCRIPTION
**Description**

Use OnceCell to cache hash computations for a single block in a thread safe way. It also doesn't require the block to be mutable in order to update the cache, which is ideal.

On a mac M1:
- The first hash computation (for a default block) takes about 150-450 μs. Storing it in the OnceCell is about 10μs.
- The subsequent hash() calls that get from the cache take ~40ns (10k times better).

Follow-up from #962 
closes #1014
