### PR TITLE
fix(l1): use latest block base fee as default gas price

### DIFF
--- a/crates/networking/rpc/eth/gas_price.rs
+++ b/crates/networking/rpc/eth/gas_price.rs
@@ -1,4 +1,3 @@
-use ethereum_rust_blockchain::constants::MIN_GAS_LIMIT;
 use ethereum_rust_storage::Store;
 use tracing::error;
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

Starting at the genesis we do not have a history of blocks to compute the mean gas price, hence we added a default gas price in a previous fix to this endpoint handler. The problem now is that this default value is usually lower than the base fee, preventing the transactions from being included.

**Description**

We now use the double of the latest block base fee as the default gas price either when there's no block history (we're at the genesis) or the mean gas price is 0 (a dev blockchain is advancing with empty blocks).

