### PR TITLE
refactor(l2): add `-w` flag to cmds that send txs

### DIFF
--- a/cmd/ethereum_rust_l2/src/commands/wallet.rs
+++ b/cmd/ethereum_rust_l2/src/commands/wallet.rs
@@ -42,11 +42,17 @@ pub(crate) enum Command {
             help = "Specify the wallet in which you want to deposit your funds."
         )]
         to: Option<Address>,
+        #[clap(short = 'w', required = false)]
+        wait_for_receipt: bool,
         #[clap(long, short = 'e', required = false)]
         explorer_url: bool,
     },
     #[clap(about = "Finalize a pending withdrawal.")]
-    ClaimWithdraw { l2_withdrawal_tx_hash: H256 },
+    ClaimWithdraw {
+        l2_withdrawal_tx_hash: H256,
+        #[clap(short = 'w', required = false)]
+        wait_for_receipt: bool,
+    },
     #[clap(about = "Transfer funds to another wallet.")]
     Transfer {
         // TODO: Parse ether instead.
@@ -56,6 +62,10 @@ pub(crate) enum Command {
         token_address: Option<Address>,
         #[clap(long = "to")]
         to: Address,
+        #[clap(long = "nonce")]
+        nonce: Option<u64>,
+        #[clap(short = 'w', required = false)]
+        wait_for_receipt: bool,
         #[clap(
             long = "l1",
             required = false,
@@ -79,6 +89,8 @@ pub(crate) enum Command {
             help = "Specify the token address, the base token is used as default."
         )]
         token_address: Option<Address>,
+        #[clap(short = 'w', required = false)]
+        wait_for_receipt: bool,
         #[clap(long, short = 'e', required = false)]
         explorer_url: bool,
     },
@@ -121,6 +133,8 @@ pub(crate) enum Command {
         gas_price: Option<u64>,
         #[clap(long = "priority-gas-price", required = false)]
         priority_gas_price: Option<u64>,
+        #[clap(short = 'w', required = false)]
+        wait_for_receipt: bool,
     },
     #[clap(about = "Make a call to a contract")]
     Call {
@@ -177,6 +191,8 @@ pub(crate) enum Command {
         gas_price: Option<u64>,
         #[clap(long = "priority-gas-price", required = false)]
         priority_gas_price: Option<u64>,
+        #[clap(short = 'w', required = false)]
+        wait_for_receipt: bool,
     },
 }
 
@@ -258,6 +274,7 @@ impl Command {
                 amount,
                 token_address,
                 to,
+                wait_for_receipt,
                 explorer_url: _,
             } => {
                 if to.is_some() {
@@ -275,7 +292,9 @@ impl Command {
                         amount,
                         token_address: None,
                         to: cfg.contracts.common_bridge,
+                        wait_for_receipt,
                         l1: true,
+                        nonce: None,
                         explorer_url: false,
                     }
                     .run(cfg)
@@ -285,6 +304,7 @@ impl Command {
             }
             Command::ClaimWithdraw {
                 l2_withdrawal_tx_hash,
+                wait_for_receipt,
             } => {
                 let (withdrawal_l2_block_number, claimed_amount) = match rollup_client
                     .get_transaction_by_hash(l2_withdrawal_tx_hash)
@@ -329,11 +349,17 @@ impl Command {
                     .await?;
 
                 println!("Withdrawal claim sent: {tx_hash:#x}");
+
+                if wait_for_receipt {
+                    wait_for_transaction_receipt(&eth_client, tx_hash).await?;
+                }
             }
             Command::Transfer {
                 amount,
                 token_address,
                 to,
+                nonce,
+                wait_for_receipt,
                 l1,
                 explorer_url: _,
             } => {
@@ -351,7 +377,7 @@ impl Command {
                     } else {
                         cfg.network.l2_chain_id
                     },
-                    nonce: client.get_nonce(from).await?,
+                    nonce: nonce.unwrap_or(client.get_nonce(from).await?),
                     max_fee_per_gas: client.get_gas_price().await?.as_u64() * 100,
                     gas_limit: 21000 * 100,
                     ..Default::default()
@@ -369,12 +395,17 @@ impl Command {
                     "[{}] Transfer sent: {tx_hash:#x}",
                     if l1 { "L1" } else { "L2" }
                 );
+
+                if wait_for_receipt {
+                    wait_for_transaction_receipt(&client, tx_hash).await?;
+                }
             }
             Command::Withdraw {
                 amount,
                 to,
                 nonce,
                 token_address: _,
+                wait_for_receipt,
                 explorer_url: _,
             } => {
                 let withdraw_transaction = PrivilegedL2Transaction {
@@ -393,6 +424,10 @@ impl Command {
                     .await?;
 
                 println!("Withdrawal sent: {tx_hash:#x}");
+
+                if wait_for_receipt {
+                    wait_for_transaction_receipt(&rollup_client, tx_hash).await?;
+                }
             }
             Command::WithdrawalProof { tx_hash } => {
                 let (_index, path) = get_withdraw_merkle_proof(&rollup_client, tx_hash).await?;
@@ -414,6 +449,7 @@ impl Command {
                 gas_limit,
                 gas_price,
                 priority_gas_price,
+                wait_for_receipt,
             } => {
                 let client = match l1 {
                     true => eth_client,
@@ -442,6 +478,10 @@ impl Command {
                     "[{}] Transaction sent: {tx_hash:#x}",
                     if l1 { "L1" } else { "L2" }
                 );
+
+                if wait_for_receipt {
+                    wait_for_transaction_receipt(&client, tx_hash).await?;
+                }
             }
             Command::Call {
                 to,
@@ -482,6 +522,7 @@ impl Command {
                 gas_limit,
                 gas_price,
                 priority_gas_price,
+                wait_for_receipt,
             } => {
                 let client = match l1 {
                     true => eth_client,
@@ -507,8 +548,21 @@ impl Command {
 
                 println!("Contract deployed in tx: {deployment_tx_hash:#x}");
                 println!("Contract address: {deployed_contract_address:#x}");
+
+                if wait_for_receipt {
+                    wait_for_transaction_receipt(&client, deployment_tx_hash).await?;
+                }
             }
         };
         Ok(())
     }
+}
+
+pub async fn wait_for_transaction_receipt(client: &EthClient, tx_hash: H256) -> eyre::Result<()> {
+    println!("Waiting for transaction receipt...");
+    while client.get_transaction_receipt(tx_hash).await?.is_none() {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+    println!("Transaction confirmed");
+    Ok(())
 }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

Nowadays, all the commands that send transactions do not wait for transaction receipts. If you run the same command multiple times the same transaction with the same nonce is going to be sent to the node; another problem is that the users have to perform additional steps to make sure that their transaction was finalized or not.

As this is not an implementation problem but a misuse of the CLI, it'd be good for users to also have the option to wait for their transactions to be finalized.

**Description**

Adds a `-w` flag to the cmds `deploy`, `transfer`, `send`, `deposit`, `withdraw`, and `claim-withdraw` which when set, waits for the transaction sent to be finalized (a.k.a. wait for its receipt).

