### PR TITLE
fix(levm): fix world state error between levm and revm. balance substraction

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -448,10 +448,11 @@ impl VM {
             self.cache.add_account(&contract_address, &created_contract);
         }
 
-        let sender_account = self.get_account(&sender);
+        let mut sender_account = self.get_account(&sender);
         let coinbase_address = self.env.coinbase;
 
-        sender_account
+
+        sender_account.info.balance = sender_account
             .info
             .balance
             .checked_sub(U256::from(report.gas_used) * self.env.gas_price)


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Balance substraction wasn't being appllied and state was turning out to be incorrect after execution. This fixes it.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

