### PR TITLE
fix(levm): fix calldataload (and add sload gas consumption)

### DIFF
--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -541,12 +541,12 @@ fn simulate_tx(
         &mut evm_state(storage, block_header.compute_block_hash()),
         spec_id,
     )? {
-        // ExecutionResult::Revert {
-        //     gas_used: _,
-        //     output,
-        // } => Err(RpcErr::Revert {
-        //     data: format!("0x{:#x}", output),
-        // }),
+        ExecutionResult::Revert {
+            gas_used: _,
+            output,
+        } => Err(RpcErr::Revert {
+            data: format!("0x{:#x}", output),
+        }),
         ExecutionResult::Halt { reason, gas_used } => Err(RpcErr::Halt { reason, gas_used }),
         success => Ok(success),
     }

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -541,12 +541,12 @@ fn simulate_tx(
         &mut evm_state(storage, block_header.compute_block_hash()),
         spec_id,
     )? {
-        ExecutionResult::Revert {
-            gas_used: _,
-            output,
-        } => Err(RpcErr::Revert {
-            data: format!("0x{:#x}", output),
-        }),
+        // ExecutionResult::Revert {
+        //     gas_used: _,
+        //     output,
+        // } => Err(RpcErr::Revert {
+        //     data: format!("0x{:#x}", output),
+        // }),
         ExecutionResult::Halt { reason, gas_used } => Err(RpcErr::Halt { reason, gas_used }),
         success => Ok(success),
     }

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -108,18 +108,24 @@ impl VM {
             .try_into()
             .unwrap_or(usize::MAX);
 
-        // Read calldata from offset to the end
-        let data = current_call_frame.calldata.slice(offset..);
+        // This check is because if offset is larger than the calldata then we should push 0 to the stack.
+        let result = if offset < current_call_frame.calldata.len() {
+            // Read calldata from offset to the end
+            let data = current_call_frame.calldata.slice(offset..);
 
-        // Get the 32 bytes from the data slice, padding with 0 if fewer than 32 bytes are available
-        let mut final_data = [0u8; 32];
-        for (i, byte) in data.iter().take(32).enumerate() {
-            final_data[i] = *byte;
-        }
+            // Get the 32 bytes from the data slice, padding with 0 if fewer than 32 bytes are available
+            let mut final_data = [0u8; 32];
+            for (i, byte) in data.iter().take(32).enumerate() {
+                final_data[i] = *byte;
+            }
 
-        let result = U256::from_big_endian(&final_data);
+            U256::from_big_endian(&final_data)
+        } else {
+            U256::zero()
+        };
+
         current_call_frame.stack.push(result)?;
-
+        
         Ok(OpcodeSuccess::Continue)
     }
 

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -113,9 +113,9 @@ impl VM {
 
             // Get the 32 bytes from the data slice, padding with 0 if fewer than 32 bytes are available
             let mut padded_calldata = [0u8; 32];
-            for (i, byte) in calldata.iter().take(32).enumerate() {
-                padded_calldata[i] = *byte;
-            }
+            let data_len_to_copy = calldata.len().min(32);
+
+            padded_calldata[..data_len_to_copy].copy_from_slice(&calldata[..data_len_to_copy]);
 
             U256::from_big_endian(&padded_calldata)
         } else {

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -125,7 +125,7 @@ impl VM {
         };
 
         current_call_frame.stack.push(result)?;
-        
+
         Ok(OpcodeSuccess::Continue)
     }
 

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -107,7 +107,7 @@ impl VM {
             .pop()?
             .try_into()
             .unwrap_or(usize::MAX);
-        
+
         // Read calldata from offset to the end
         let data = current_call_frame.calldata.slice(offset..);
 

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -111,20 +111,13 @@ impl VM {
         // Read calldata from offset to the end
         let data = current_call_frame.calldata.slice(offset..);
 
-        // Get first 32 bytes of data from offset, if read data is less than 32 bytes, fill the rest with 0
-        let mut final_data = vec![];
-        for i in 0..32 {
-            if i < data.len() {
-                final_data.push(data[i]);
-            }
-            else {
-                final_data.push(0);
-            }
+        // Get the 32 bytes from the data slice, padding with 0 if fewer than 32 bytes are available
+        let mut final_data = [0u8; 32];
+        for (i, byte) in data.iter().take(32).enumerate() {
+            final_data[i] = *byte;
         }
-        let final_data = Bytes::from(final_data);
 
         let result = U256::from_big_endian(&final_data);
-        
         current_call_frame.stack.push(result)?;
 
         Ok(OpcodeSuccess::Continue)

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -100,8 +100,6 @@ impl VM {
     ) -> Result<OpcodeSuccess, VMError> {
         self.increase_consumed_gas(current_call_frame, gas_cost::CALLDATALOAD)?;
 
-        println!("calldata: {:?}", current_call_frame.calldata);
-
         let offset: usize = current_call_frame
             .stack
             .pop()?

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -111,15 +111,15 @@ impl VM {
         // This check is because if offset is larger than the calldata then we should push 0 to the stack.
         let result = if offset < current_call_frame.calldata.len() {
             // Read calldata from offset to the end
-            let data = current_call_frame.calldata.slice(offset..);
+            let calldata = current_call_frame.calldata.slice(offset..);
 
             // Get the 32 bytes from the data slice, padding with 0 if fewer than 32 bytes are available
-            let mut final_data = [0u8; 32];
-            for (i, byte) in data.iter().take(32).enumerate() {
-                final_data[i] = *byte;
+            let mut padded_calldata = [0u8; 32];
+            for (i, byte) in calldata.iter().take(32).enumerate() {
+                padded_calldata[i] = *byte;
             }
 
-            U256::from_big_endian(&final_data)
+            U256::from_big_endian(&padded_calldata)
         } else {
             U256::zero()
         };

--- a/crates/vm/levm/tests/tests.rs
+++ b/crates/vm/levm/tests/tests.rs
@@ -2256,16 +2256,66 @@ fn jumpi_for_zero() {
     assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 19);
 }
 
+// This test is just for trying things out, not a real test. But it is useful to have this as an example for conversions between bytes and u256.
+#[test]
+fn testing_bytes_u256_conversion(){
+    // From Bytes to U256 to Bytes again
+    let data: Bytes = vec![
+        0x11, 0x22, 0x33, 0x44
+    ].into();
+    println!("{:?}", data);
+
+    let result = U256::from_big_endian(&data);
+    println!("{:?}", result);
+
+    // Convert from U256 to bytes
+    let mut temp_bytes = vec![0u8; 32];
+    result.to_big_endian(&mut temp_bytes);
+    println!("{:?}", temp_bytes);
+
+    let mut i = 0;
+    while i < temp_bytes.len() {
+        if temp_bytes[i] == 0 {
+            temp_bytes.remove(i);
+        }
+        else {
+            i += 1;
+        }
+    }
+
+    println!("{:?}", temp_bytes);
+    let temp_bytes = Bytes::from(temp_bytes);
+    println!("{:?}", temp_bytes);
+
+    // Pad the rest with zeroes
+    let mut final_data = vec![];
+    for i in 0..32 {
+        if i < temp_bytes.len() {
+            final_data.push(temp_bytes[i]);
+        }
+        else {
+            final_data.push(0);
+        }
+    }
+
+    let final_data = Bytes::from(final_data);
+    println!("{:?}", final_data);
+
+    let result = U256::from_big_endian(&final_data);
+    println!("{:?}", result);
+}
+
+
 #[test]
 fn calldataload() {
     let calldata = vec![
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E,
-        0x0F, 0x10,
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
     ]
     .into();
+    println!("{:?}", calldata);
     let ops = vec![
-        Operation::Push((32, U256::from(0))), // offset
+        Operation::Push((32, U256::from(1))), // offset
         Operation::CallDataLoad,
         Operation::Stop,
     ];
@@ -2281,9 +2331,7 @@ fn calldataload() {
     assert_eq!(
         top_of_stack,
         U256::from_big_endian(&[
-            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE,
-            0xFF, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C,
-            0x0D, 0x0E, 0x0F, 0x10
+            0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
         ])
     );
     assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 6);

--- a/crates/vm/levm/tests/tests.rs
+++ b/crates/vm/levm/tests/tests.rs
@@ -2258,11 +2258,9 @@ fn jumpi_for_zero() {
 
 // This test is just for trying things out, not a real test. But it is useful to have this as an example for conversions between bytes and u256.
 #[test]
-fn testing_bytes_u256_conversion(){
+fn testing_bytes_u256_conversion() {
     // From Bytes to U256 to Bytes again
-    let data: Bytes = vec![
-        0x11, 0x22, 0x33, 0x44
-    ].into();
+    let data: Bytes = vec![0x11, 0x22, 0x33, 0x44].into();
     println!("{:?}", data);
 
     let result = U256::from_big_endian(&data);
@@ -2277,8 +2275,7 @@ fn testing_bytes_u256_conversion(){
     while i < temp_bytes.len() {
         if temp_bytes[i] == 0 {
             temp_bytes.remove(i);
-        }
-        else {
+        } else {
             i += 1;
         }
     }
@@ -2292,8 +2289,7 @@ fn testing_bytes_u256_conversion(){
     for i in 0..32 {
         if i < temp_bytes.len() {
             final_data.push(temp_bytes[i]);
-        }
-        else {
+        } else {
             final_data.push(0);
         }
     }
@@ -2304,7 +2300,6 @@ fn testing_bytes_u256_conversion(){
     let result = U256::from_big_endian(&final_data);
     println!("{:?}", result);
 }
-
 
 #[test]
 fn calldataload() {
@@ -2331,7 +2326,9 @@ fn calldataload() {
     assert_eq!(
         top_of_stack,
         U256::from_big_endian(&[
-            0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+            0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00
         ])
     );
     assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 6);


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Calldataload was giving problems the way it was implemented. Changed implementation and now it doesn't produce an error in execution.

Description:
- Fixes CALLDATALOAD, before it only worked in the ideal scenario where the data read is 32 bytes long, but that does not always happen. Sometimes calldata is less than 32 bytes and other times the offset is so high that from there to the end there are not 32 bytes. -> Solution was to fill the rest of the bytes with zeros.
- Added SLOAD opcode gas implementation (slightly modified from #1053) because the function I was testing in the solidity contract requires that to be implemented.


Results:
- Now sending a transaction that calls the function `number()(uint256)` in a basic solidity contract seems to work properly.
- As a side effect of fixing that it also works to call the function `increment()` of the basic contract.

What's left:
- Gas refunds haven't been implemented in SSTORE yet so if I were to set the storage to 0 then it wouldn't work properly

