### PR TITLE
fix(l2): prover add fixes

### DIFF
--- a/crates/l2/proposer/mod.rs
+++ b/crates/l2/proposer/mod.rs
@@ -208,6 +208,11 @@ impl Proposer {
         };
         let payload_attributes = PayloadAttributesV3 {
             timestamp: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
+            // Setting the COINBASE address / fee_recipient.
+            // TODO: revise it, maybe we would like to have this set with an envar
+            suggested_fee_recipient: Address::from_slice(
+                &hex::decode("0007a881CD95B1484fca47615B64803dad620C8d").unwrap(),
+            ),
             ..Default::default()
         };
         let fork_choice_response = match self

--- a/crates/l2/prover/zkvm/interface/guest/Cargo.toml
+++ b/crates/l2/prover/zkvm/interface/guest/Cargo.toml
@@ -13,6 +13,11 @@ ethereum_rust-rlp = { path = "../../../../../common/rlp" }
 ethereum_rust-vm = { path = "../../../../../vm", default-features = false }
 ethereum_rust-blockchain = { path = "../../../../../blockchain", default-features = false }
 
+[build-dependencies]
+## cc version ^1.1.31 breaks the compilation.
+## https://github.com/rust-lang/cc-rs/compare/cc-v1.1.34...main
+cc = "=1.1.31"
+
 [patch.crates-io]
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
 k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.0" }


### PR DESCRIPTION
**Motivation**

Some minor fixes regarding the L2 prover were added.

**Description**

- The cc build-dependency for the guest zkVM was downgraded to 1.1.31.
- The fee_recipient address was changed with an address specified in the genesis. &rarr; To be tracked in ISSUEssue #1070

