### PR TITLE
fix(l2): rm duplicated CI logic 

### DIFF
--- a/.github/workflows/l2_contracts.yaml
+++ b/.github/workflows/l2_contracts.yaml
@@ -14,30 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deployer:
-    name: L2 Contracts CI
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        action:
-          - command: check
-          - command: clippy
-          # clippy::large_enum_variant warning for the EvmState enum
-          # from rust 1.82.0
-            args: -- -D warnings -A clippy::large_enum_variant
-          - command: fmt
-            args: --all -- --check
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-      - name: Add Rust Cache
-        uses: Swatinem/rust-cache@v2
-      - name: ${{ matrix.action.command }} Command
-        run: |
-          cd crates/l2/contracts
-          cargo ${{ matrix.action.command }} ${{ matrix.action.args }}
-
   test_compilation:
     name: Compile Contracts
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Motivation**

The `contracts` CI was running a linter, it's not needed since those validations are performed by the global CI linter.

**Description**

Remove unneeded CI job.

