### PR TITLE
fix(levm): fix some problems with contracts that use CALL

### DIFF
--- a/crates/vm/levm/.gitignore
+++ b/crates/vm/levm/.gitignore
@@ -1,3 +1,3 @@
 *.tar.gz
 
-tests/ef_testcases
+tests/ef/tests

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -389,15 +389,15 @@ impl VM {
 
         self.env.consumed_gas = initial_gas;
 
-        let mut current_call_frame = self.call_frames.pop().unwrap();
+        let mut initial_call_frame = self.call_frames.pop().unwrap();
+        let sender = initial_call_frame.msg_sender;
 
-        let mut report = self.execute(&mut current_call_frame);
-        let sender = self.call_frames.first().unwrap().msg_sender;
+        let mut report = self.execute(&mut initial_call_frame);
 
         // This cost applies both for call and create
         // 4 gas for each zero byte in the transaction data 16 gas for each non-zero byte in the transaction.
         let mut calldata_cost = 0;
-        for byte in &self.call_frames[0].calldata {
+        for byte in &initial_call_frame.calldata {
             if *byte != 0 {
                 calldata_cost += 16;
             } else {
@@ -433,10 +433,10 @@ impl VM {
             // Charge 22100 gas for each storage variable set
 
             // GInitCodeword * number_of_words rounded up. GinitCodeWord = 2
-            let number_of_words = self.call_frames[0].calldata.chunks(32).len() as u64;
+            let number_of_words = initial_call_frame.calldata.chunks(32).len() as u64;
             report.add_gas_with_max(number_of_words * 2, max_gas);
 
-            let contract_address = self.call_frames.first().unwrap().to;
+            let contract_address = initial_call_frame.to;
             let mut created_contract = self.get_account(&contract_address);
 
             created_contract.info.bytecode = contract_code;
@@ -453,13 +453,7 @@ impl VM {
             .checked_sub(U256::from(report.gas_used) * self.env.gas_price)
             .ok_or(VMError::OutOfGas)?;
 
-        let call_frame = self
-            .call_frames
-            .first()
-            .ok_or(VMError::InternalError)?
-            .clone();
-
-        let receiver_address = call_frame.to;
+        let receiver_address = initial_call_frame.to;
         let mut receiver_account = self.get_account(&receiver_address);
         // If execution was successful we want to transfer value from sender to receiver
         if report.is_success() {
@@ -467,12 +461,12 @@ impl VM {
             sender_account.info.balance = sender_account
                 .info
                 .balance
-                .checked_sub(call_frame.msg_value)
+                .checked_sub(initial_call_frame.msg_value)
                 .ok_or(VMError::OutOfGas)?; // This error shouldn't be OutOfGas
             receiver_account.info.balance = receiver_account
                 .info
                 .balance
-                .checked_add(call_frame.msg_value)
+                .checked_add(initial_call_frame.msg_value)
                 .ok_or(VMError::OutOfGas)?; // This error shouldn't be OutOfGas
         }
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
- The objective of this PR is make a CALL contract work.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- We were accessing the initial callframe of the VM with `self.call_frames[0]`, but this is actually not the initial callframe, because this one is pushed at the end of execution. That's why I changed how we access that callframe's information

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

