### PR TITLE
fix(levm): fix create2 address generation

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -11,13 +11,13 @@ use bytes::Bytes;
 use ethereum_rust_core::{types::TxKind, Address, H256, U256};
 use ethereum_rust_rlp;
 use ethereum_rust_rlp::encode::RLPEncode;
+use keccak_hash::keccak;
 use sha3::{Digest, Keccak256};
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
     sync::Arc,
 };
-use keccak_hash::keccak;
 
 pub type Storage = HashMap<U256, H256>;
 

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -701,7 +701,7 @@ impl VM {
 
         let new_address = match salt {
             Some(salt) => {
-                Self::calculate_create2_address(current_call_frame.msg_sender, &code, salt)
+                Self::calculate_create2_address(current_call_frame.to, &code, salt)
             }
             None => Self::calculate_create_address(
                 current_call_frame.msg_sender,


### PR DESCRIPTION
**Motivation**

The address generation in create2 was being done wrong, the goal is to correct it.

**Description**

The implementation is inspired in [the implementation in deployer.rs](https://github.com/lambdaclass/lambda_ethereum_rust/blob/main/crates/l2/contracts/deployer.rs#L221) of L2 crate. One way to compare it is to compare the outputs of both functions.

Closes #1091 

