### PR TITLE
feat(l1): don't store trie nodes if they are already inlined on their parent

### DIFF
--- a/crates/storage/trie/node/branch.rs
+++ b/crates/storage/trie/node/branch.rs
@@ -349,7 +349,7 @@ mod test {
                 1 => leaf { vec![0, 16] => vec![0x34, 0x56, 0x78, 0x9A] },
             }
         };
-        let path = Nibbles::from_hex(vec![2]);
+        let path = Nibbles::from_bytes(&[2]);
         let value = vec![0x3];
 
         let node = node


### PR DESCRIPTION
**Motivation**
We are currently storing nodes on the DB even if they are already inlined in their parent node. This is not only storage-inefficient but it also needs special handling when verifying proofs or importing trie nodes from other clients (such as in snap sync) as inlined nodes will not be sent separately.
This PR aims to solve this issue at `TrieState` level, so that the change is invisible to the main trie logic.
The state will skip insertion for inlined node hashes and will decode them instead of fetching from the db upon lookups

<!-- Why does this pull request exist? What are its goals? -->

**Description**
* `TrieState::insert` now skips node hashes that represent inlined nodes
* `TrieState::get` now decoded the node if it is inlined instead of performing a db lookup

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but is needed in order to validate and integrate output from snap sync requests #184 

