### PR TITLE
feat(core): add nonce, balance and chain id validations to send raw tx endpoint

### DIFF
--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -60,8 +60,8 @@ pub enum MempoolError {
     BlobsBundleWrongLen,
     #[error("Nonce for account too low")]
     InvalidNonce,
-    #[error("Transaction chain id mismatch")]
-    InvalidChainId,
+    #[error("Transaction chain id mismatch, expected chain id: {0}")]
+    InvalidChainId(u64),
     #[error("Account does not have enough balance to cover the tx cost")]
     NotEnoughBalance,
     #[error("Transaction gas fields are invalid")]

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -58,6 +58,14 @@ pub enum MempoolError {
     BlobTxNoBlobsBundle,
     #[error("Mismatch between blob versioned hashes and blobs bundle content length")]
     BlobsBundleWrongLen,
+    #[error("Nonce for account too low")]
+    InvalidNonce,
+    #[error("Transaction chain id mismatch")]
+    InvalidChainId,
+    #[error("Account does not have enough balance to cover the tx cost")]
+    NotEnoughBalance,
+    #[error("Transaction gas fields are invalid")]
+    InvalidTxGasvalues,
 }
 
 #[derive(Debug)]

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -218,7 +218,10 @@ fn validate_transaction(tx: &Transaction, store: Store) -> Result<(), MempoolErr
             .ok_or(MempoolError::InvalidTxGasvalues)?
             .into();
         let gas_limit = U256::from(tx.gas_limit());
-        let tx_cost: U256 = effective_gas_price * gas_limit + tx.value();
+        let tx_cost = U256::saturating_add(
+            U256::saturating_mul(effective_gas_price, gas_limit),
+            tx.value(),
+        );
 
         if tx_cost > sender_acc_info.balance {
             return Err(MempoolError::NotEnoughBalance);
@@ -230,7 +233,7 @@ fn validate_transaction(tx: &Transaction, store: Store) -> Result<(), MempoolErr
 
     if let Some(chain_id) = tx.chain_id() {
         if chain_id != config.chain_id {
-            return Err(MempoolError::InvalidChainId);
+            return Err(MempoolError::InvalidChainId(config.chain_id));
         }
     }
 

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -213,15 +213,9 @@ fn validate_transaction(tx: &Transaction, store: Store) -> Result<(), MempoolErr
             return Err(MempoolError::InvalidNonce);
         }
 
-        let effective_gas_price: U256 = tx
-            .effective_gas_price(header.base_fee_per_gas)
-            .ok_or(MempoolError::InvalidTxGasvalues)?
-            .into();
-        let gas_limit = U256::from(tx.gas_limit());
-        let tx_cost = U256::saturating_add(
-            U256::saturating_mul(effective_gas_price, gas_limit),
-            tx.value(),
-        );
+        let tx_cost = tx
+            .cost_without_base_fee()
+            .ok_or(MempoolError::InvalidTxGasvalues)?;
 
         if tx_cost > sender_acc_info.balance {
             return Err(MempoolError::NotEnoughBalance);

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -168,9 +168,6 @@ fn validate_transaction(tx: &Transaction, store: Store) -> Result<(), MempoolErr
     let header_no = store
         .get_latest_block_number()?
         .ok_or(MempoolError::NoBlockHeaderError)?;
-    let block_header = store
-        .get_block_header(header_no)?
-        .ok_or(MempoolError::NoBlockHeaderError)?;
     let header = store
         .get_block_header(header_no)?
         .ok_or(MempoolError::NoBlockHeaderError)?;
@@ -217,7 +214,7 @@ fn validate_transaction(tx: &Transaction, store: Store) -> Result<(), MempoolErr
         }
 
         let effective_gas_price: U256 = tx
-            .effective_gas_price(block_header.base_fee_per_gas)
+            .effective_gas_price(header.base_fee_per_gas)
             .ok_or(MempoolError::InvalidTxGasvalues)?
             .into();
         let gas_limit = U256::from(tx.gas_limit());

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -144,6 +144,28 @@ impl Transaction {
             Transaction::PrivilegedL2Transaction(_) => TxType::Privileged,
         }
     }
+
+    pub fn effective_gas_price(&self, base_fee_per_gas: Option<u64>) -> Option<u64> {
+        match self.tx_type() {
+            TxType::Legacy => Some(self.gas_price()),
+            TxType::EIP2930 => Some(self.gas_price()),
+            TxType::EIP1559 => {
+                let priority_fee_per_gas = min(
+                    self.max_priority_fee()?,
+                    self.max_fee_per_gas()? - base_fee_per_gas?,
+                );
+                Some(priority_fee_per_gas + base_fee_per_gas?)
+            }
+            TxType::EIP4844 => {
+                let priority_fee_per_gas = min(
+                    self.max_priority_fee()?,
+                    self.max_fee_per_gas()? - base_fee_per_gas?,
+                );
+                Some(priority_fee_per_gas + base_fee_per_gas?)
+            }
+            TxType::Privileged => Some(self.gas_price()),
+        }
+    }
 }
 
 impl RLPEncode for Transaction {

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -166,6 +166,21 @@ impl Transaction {
             TxType::Privileged => Some(self.gas_price()),
         }
     }
+
+    pub fn cost_without_base_fee(&self) -> Option<U256> {
+        let price = match self.tx_type() {
+            TxType::Legacy => self.gas_price(),
+            TxType::EIP2930 => self.gas_price(),
+            TxType::EIP1559 => self.max_fee_per_gas()?,
+            TxType::EIP4844 => self.max_fee_per_gas()?,
+            TxType::Privileged => self.gas_price(),
+        };
+
+        Some(U256::saturating_add(
+            U256::saturating_mul(price.into(), self.gas_limit().into()),
+            self.value(),
+        ))
+    }
 }
 
 impl RLPEncode for Transaction {

--- a/crates/vm/vm.rs
+++ b/crates/vm/vm.rs
@@ -84,7 +84,7 @@ cfg_if::cfg_if! {
             Environment,
         };
         use std::{collections::HashMap, sync::Arc};
-        use ethereum_rust_core::types::{code_hash, TxType};
+        use ethereum_rust_core::types::code_hash;
 
         /// Executes all transactions in a block and returns their receipts.
         pub fn execute_block(
@@ -160,25 +160,7 @@ cfg_if::cfg_if! {
             block_header: &BlockHeader,
             db: Arc<dyn LevmDatabase>,
         ) -> Result<TransactionReport, VMError> {
-            let gas_price: U256 = match tx.tx_type() {
-                TxType::Legacy => tx.gas_price().into(),
-                TxType::EIP2930 => tx.gas_price().into(),
-                TxType::EIP1559 => {
-                    let priority_fee_per_gas = min(
-                        tx.max_priority_fee().unwrap(),
-                        tx.max_fee_per_gas().unwrap() - block_header.base_fee_per_gas.unwrap(),
-                    );
-                    (priority_fee_per_gas + block_header.base_fee_per_gas.unwrap()).into()
-                }
-                TxType::EIP4844 => {
-                    let priority_fee_per_gas = min(
-                        tx.max_priority_fee().unwrap(),
-                        tx.max_fee_per_gas().unwrap() - block_header.base_fee_per_gas.unwrap(),
-                    );
-                    (priority_fee_per_gas + block_header.base_fee_per_gas.unwrap()).into()
-                }
-                TxType::Privileged => tx.gas_price().into(),
-            };
+            let gas_price : U256 = tx.effective_gas_price(block_header.base_fee_per_gas).ok_or(VMError::InvalidTransaction)?.into();
 
             let env = Environment {
                 origin: tx.sender(),


### PR DESCRIPTION
**Motivation**

This PR adds checks for invalid nonce, insufficient balance and invalid chain id values for the `sendRawTransaction` endpoint. Without them, sometimes we would get invalid transactions stuck in the mempool, which would make accounts get stuck.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

