### PR TITLE
fix(l1): remove diff from hive and assertoor script

### DIFF
--- a/.github/workflows/hive_and_assertoor.yaml
+++ b/.github/workflows/hive_and_assertoor.yaml
@@ -66,17 +66,10 @@ jobs:
             run_command: make run-hive-on-latest SIMULATION=devp2p TEST_PATTERN="discv4"
           - simulation: snap
             name: "Devp2p snap tests"
-<<<<<<< HEAD
             run_command: make run-hive-on-latest SIMULATION=devp2p TEST_PATTERN="/AccountRange|StorageRanges|ByteCodes|TrieNodes"
-=======
-            run_command: make run-hive-on-latest SIMULATION=devp2p TEST_PATTERN="/AccountRange|StorageRanges|ByteCodes"
-          - simulation: eth
-            name: "Devp2p eth tests"
-            run_command: make run-hive SIMULATION=devp2p TEST_PATTERN="eth/getblockheaders"
           - simulation: eth
             name: "Devp2p eth tests"
             run_command: make run-hive SIMULATION=devp2p TEST_PATTERN="eth/getblockheaders|getblockbodies"
->>>>>>> d15a89c9d7504b7f3eca3f20789dc38c449ee456
           - simulation: engine
             name: "Engine tests"
             run_command:  make run-hive-on-latest SIMULATION=ethereum/engine TEST_PATTERN="/Blob Transactions On Block 1, Cancun Genesis|Blob Transactions On Block 1, Shanghai Genesis|Blob Transaction Ordering, Single Account, Single Blob|Blob Transaction Ordering, Single Account, Dual Blob|Blob Transaction Ordering, Multiple Accounts|Replace Blob Transactions|Parallel Blob Transactions|ForkchoiceUpdatedV3 Modifies Payload ID on Different Beacon Root|NewPayloadV3 After Cancun|NewPayloadV3 Versioned Hashes|ForkchoiceUpdated Version on Payload Request"


### PR DESCRIPTION
**Description**

CI was not working as there was a syntax error in the hive and assertoor github action. This PR fixes that.