### PR TITLE
fix(levm): avoid panicking in ef tests

### DIFF
--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -32,7 +32,7 @@ $(SPECTEST_VECTORS_DIR): $(SPECTEST_ARTIFACT)
 download-ef-tests: $(SPECTEST_VECTORS_DIR) ## 📥 Download EF Tests
 
 run-ef-tests: ## 🏃‍♂️ Run EF Tests
-	cargo test ef::testito -- --ignored
+	cargo test ef::testito -- --ignored --nocapture
 
 clean-ef-tests: ## 🗑️  Clean test vectors
 	rm -rf $(SPECTEST_VECTORS_DIR)

--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -32,7 +32,7 @@ $(SPECTEST_VECTORS_DIR): $(SPECTEST_ARTIFACT)
 download-ef-tests: $(SPECTEST_VECTORS_DIR) ## 📥 Download EF Tests
 
 run-ef-tests: ## 🏃‍♂️ Run EF Tests
-	cargo test ef::testito -- --ignored --nocapture
+	cargo test ef::testito -- --ignored
 
 clean-ef-tests: ## 🗑️  Clean test vectors
 	rm -rf $(SPECTEST_VECTORS_DIR)

--- a/crates/vm/levm/src/constants.rs
+++ b/crates/vm/levm/src/constants.rs
@@ -126,6 +126,14 @@ pub fn init_code_cost(init_code_length: usize) -> u64 {
     INIT_WORD_COST as u64 * (init_code_length as u64 + 31) / 32
 }
 
+pub mod create_opcode {
+    use ethereum_rust_core::U256;
+
+    pub const INIT_CODE_WORD_COST: U256 = U256([2, 0, 0, 0]);
+    pub const CODE_DEPOSIT_COST: U256 = U256([200, 0, 0, 0]);
+    pub const CREATE_BASE_COST: U256 = U256([32000, 0, 0, 0]);
+}
+
 pub const VERSIONED_HASH_VERSION_KZG: u8 = 0x01;
 pub const MAX_BLOB_NUMBER_PER_BLOCK: usize = 6;
 

--- a/crates/vm/levm/src/constants.rs
+++ b/crates/vm/levm/src/constants.rs
@@ -147,3 +147,4 @@ pub const COLD_STORAGE_ACCESS_COST: U256 = U256([2100, 0, 0, 0]);
 
 // Block constants
 pub const LAST_AVAILABLE_BLOCK_LIMIT: U256 = U256([256, 0, 0, 0]);
+pub const MAX_BLOCK_GAS_LIMIT: U256 = U256([30_000_000, 0, 0, 0]);

--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -32,6 +32,11 @@ pub enum VMError {
     NonceOverflow,
     MemoryLoadOutOfBounds,
     GasLimitPriceProductOverflow,
+    DataSizeOverflow,
+    Internal,
+    GasCostOverflow,
+    OffsetOverflow,
+    CreationCostIsTooHigh
 }
 
 #[derive(Debug, Clone)]

--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -36,7 +36,8 @@ pub enum VMError {
     Internal,
     GasCostOverflow,
     OffsetOverflow,
-    CreationCostIsTooHigh
+    CreationCostIsTooHigh,
+    MaxGasLimitExceeded,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/vm/levm/src/memory.rs
+++ b/crates/vm/levm/src/memory.rs
@@ -31,10 +31,10 @@ impl Memory {
     }
 
     pub fn load(&mut self, offset: usize) -> Result<U256, VMError> {
-        self.resize(offset + 32);
+        self.resize(offset.checked_add(32).ok_or(VMError::MemoryLoadOutOfBounds)?);
         let value_bytes: [u8; 32] = self
             .data
-            .get(offset..offset + 32)
+            .get(offset..offset.checked_add(32).ok_or(VMError::MemoryLoadOutOfBounds)?)
             .ok_or(VMError::MemoryLoadOutOfBounds)?
             .try_into()
             .unwrap();
@@ -42,38 +42,42 @@ impl Memory {
     }
 
     pub fn load_range(&mut self, offset: usize, size: usize) -> Result<Vec<u8>, VMError> {
-        self.resize(offset + size);
+        self.resize(offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?);
         self.data
-            .get(offset..offset + size)
+            .get(offset..offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?)
             .ok_or(VMError::MemoryLoadOutOfBounds)
             .map(|slice| slice.to_vec())
     }
 
-    pub fn store_bytes(&mut self, offset: usize, value: &[u8]) {
+    pub fn store_bytes(&mut self, offset: usize, value: &[u8]) -> Result<(), VMError> {
         let len = value.len();
-        self.resize(offset + len);
+        self.resize(offset.checked_add(len).ok_or(VMError::MemoryLoadOutOfBounds)?);
         self.data
-            .splice(offset..offset + len, value.iter().copied());
+            .splice(offset..offset.checked_add(len).ok_or(VMError::MemoryLoadOutOfBounds)?, value.iter().copied());
+        Ok(())
     }
 
-    pub fn store_n_bytes(&mut self, offset: usize, value: &[u8], size: usize) {
-        self.resize(offset + size);
+    pub fn store_n_bytes(&mut self, offset: usize, value: &[u8], size: usize) -> Result<(), VMError> {
+        self.resize(offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?);
         self.data
-            .splice(offset..offset + size, value.iter().copied());
+            .splice(offset..offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?, value.iter().copied());
+        Ok(())
     }
 
     pub fn size(&self) -> U256 {
         U256::from(self.data.len())
     }
 
-    pub fn copy(&mut self, src_offset: usize, dest_offset: usize, size: usize) {
-        let max_size = std::cmp::max(src_offset + size, dest_offset + size);
+    pub fn copy(&mut self, src_offset: usize, dest_offset: usize, size: usize) -> Result<(), VMError> {
+        let max_size = std::cmp::max(src_offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?, dest_offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?);
         self.resize(max_size);
         let mut temp = vec![0u8; size];
 
-        temp.copy_from_slice(&self.data[src_offset..src_offset + size]);
+        temp.copy_from_slice(&self.data[src_offset..src_offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?]);
 
-        self.data[dest_offset..dest_offset + size].copy_from_slice(&temp);
+        self.data[dest_offset..dest_offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?].copy_from_slice(&temp);
+
+        Ok(())
     }
 
     pub fn expansion_cost(&self, memory_byte_size: usize) -> Result<U256, VMError> {

--- a/crates/vm/levm/src/memory.rs
+++ b/crates/vm/levm/src/memory.rs
@@ -31,10 +31,19 @@ impl Memory {
     }
 
     pub fn load(&mut self, offset: usize) -> Result<U256, VMError> {
-        self.resize(offset.checked_add(32).ok_or(VMError::MemoryLoadOutOfBounds)?);
+        self.resize(
+            offset
+                .checked_add(32)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?,
+        );
         let value_bytes: [u8; 32] = self
             .data
-            .get(offset..offset.checked_add(32).ok_or(VMError::MemoryLoadOutOfBounds)?)
+            .get(
+                offset
+                    ..offset
+                        .checked_add(32)
+                        .ok_or(VMError::MemoryLoadOutOfBounds)?,
+            )
             .ok_or(VMError::MemoryLoadOutOfBounds)?
             .try_into()
             .unwrap();
@@ -42,25 +51,57 @@ impl Memory {
     }
 
     pub fn load_range(&mut self, offset: usize, size: usize) -> Result<Vec<u8>, VMError> {
-        self.resize(offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?);
+        self.resize(
+            offset
+                .checked_add(size)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?,
+        );
         self.data
-            .get(offset..offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?)
+            .get(
+                offset
+                    ..offset
+                        .checked_add(size)
+                        .ok_or(VMError::MemoryLoadOutOfBounds)?,
+            )
             .ok_or(VMError::MemoryLoadOutOfBounds)
             .map(|slice| slice.to_vec())
     }
 
     pub fn store_bytes(&mut self, offset: usize, value: &[u8]) -> Result<(), VMError> {
         let len = value.len();
-        self.resize(offset.checked_add(len).ok_or(VMError::MemoryLoadOutOfBounds)?);
-        self.data
-            .splice(offset..offset.checked_add(len).ok_or(VMError::MemoryLoadOutOfBounds)?, value.iter().copied());
+        self.resize(
+            offset
+                .checked_add(len)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?,
+        );
+        self.data.splice(
+            offset
+                ..offset
+                    .checked_add(len)
+                    .ok_or(VMError::MemoryLoadOutOfBounds)?,
+            value.iter().copied(),
+        );
         Ok(())
     }
 
-    pub fn store_n_bytes(&mut self, offset: usize, value: &[u8], size: usize) -> Result<(), VMError> {
-        self.resize(offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?);
-        self.data
-            .splice(offset..offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?, value.iter().copied());
+    pub fn store_n_bytes(
+        &mut self,
+        offset: usize,
+        value: &[u8],
+        size: usize,
+    ) -> Result<(), VMError> {
+        self.resize(
+            offset
+                .checked_add(size)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?,
+        );
+        self.data.splice(
+            offset
+                ..offset
+                    .checked_add(size)
+                    .ok_or(VMError::MemoryLoadOutOfBounds)?,
+            value.iter().copied(),
+        );
         Ok(())
     }
 
@@ -68,14 +109,35 @@ impl Memory {
         U256::from(self.data.len())
     }
 
-    pub fn copy(&mut self, src_offset: usize, dest_offset: usize, size: usize) -> Result<(), VMError> {
-        let max_size = std::cmp::max(src_offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?, dest_offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?);
+    pub fn copy(
+        &mut self,
+        src_offset: usize,
+        dest_offset: usize,
+        size: usize,
+    ) -> Result<(), VMError> {
+        let max_size = std::cmp::max(
+            src_offset
+                .checked_add(size)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?,
+            dest_offset
+                .checked_add(size)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?,
+        );
         self.resize(max_size);
         let mut temp = vec![0u8; size];
 
-        temp.copy_from_slice(&self.data[src_offset..src_offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?]);
+        temp.copy_from_slice(
+            &self.data[src_offset
+                ..src_offset
+                    .checked_add(size)
+                    .ok_or(VMError::MemoryLoadOutOfBounds)?],
+        );
 
-        self.data[dest_offset..dest_offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?].copy_from_slice(&temp);
+        self.data[dest_offset
+            ..dest_offset
+                .checked_add(size)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?]
+            .copy_from_slice(&temp);
 
         Ok(())
     }

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -163,9 +163,11 @@ impl VM {
             .map_err(|_err| VMError::VeryLargeNumber)?;
 
         let minimum_word_size = (size + WORD_SIZE - 1) / WORD_SIZE;
-        let memory_expansion_cost = current_call_frame
-            .memory
-            .expansion_cost(dest_offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?)?;
+        let memory_expansion_cost = current_call_frame.memory.expansion_cost(
+            dest_offset
+                .checked_add(size)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?,
+        )?;
         let gas_cost = gas_cost::CALLDATACOPY_STATIC
             + gas_cost::CALLDATACOPY_DYNAMIC_BASE * minimum_word_size
             + memory_expansion_cost;
@@ -192,7 +194,9 @@ impl VM {
             vec![0u8; size]
         };
 
-        current_call_frame.memory.store_bytes(dest_offset, &result)?;
+        current_call_frame
+            .memory
+            .store_bytes(dest_offset, &result)?;
 
         Ok(OpcodeSuccess::Continue)
     }
@@ -238,9 +242,11 @@ impl VM {
 
         let minimum_word_size = (size + WORD_SIZE - 1) / WORD_SIZE;
 
-        let memory_expansion_cost = current_call_frame
-            .memory
-            .expansion_cost(dest_offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?)?;
+        let memory_expansion_cost = current_call_frame.memory.expansion_cost(
+            dest_offset
+                .checked_add(size)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?,
+        )?;
 
         let gas_cost = gas_cost::CODECOPY_STATIC
             + gas_cost::CODECOPY_DYNAMIC_BASE * minimum_word_size
@@ -250,9 +256,13 @@ impl VM {
 
         let bytecode_len = current_call_frame.bytecode.len();
         let code = if offset < bytecode_len {
-            current_call_frame
-                .bytecode
-                .slice(offset..(offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?).min(bytecode_len))
+            current_call_frame.bytecode.slice(
+                offset
+                    ..(offset
+                        .checked_add(size)
+                        .ok_or(VMError::MemoryLoadOutOfBounds)?)
+                    .min(bytecode_len),
+            )
         } else {
             vec![0u8; size].into()
         };
@@ -323,9 +333,11 @@ impl VM {
             .map_err(|_| VMError::VeryLargeNumber)?;
 
         let minimum_word_size = (size + WORD_SIZE - 1) / WORD_SIZE;
-        let memory_expansion_cost = current_call_frame
-            .memory
-            .expansion_cost(dest_offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?)?;
+        let memory_expansion_cost = current_call_frame.memory.expansion_cost(
+            dest_offset
+                .checked_add(size)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?,
+        )?;
         let gas_cost =
             gas_cost::EXTCODECOPY_DYNAMIC_BASE * minimum_word_size + memory_expansion_cost;
 
@@ -344,14 +356,27 @@ impl VM {
             .bytecode
             .clone();
 
-        if bytecode.len() < offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)? {
+        if bytecode.len()
+            < offset
+                .checked_add(size)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?
+        {
             let mut extended_code = bytecode.to_vec();
-            extended_code.resize(offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?, 0);
+            extended_code.resize(
+                offset
+                    .checked_add(size)
+                    .ok_or(VMError::MemoryLoadOutOfBounds)?,
+                0,
+            );
             bytecode = Bytes::from(extended_code);
         }
-        current_call_frame
-            .memory
-            .store_bytes(dest_offset, &bytecode[offset..offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?])?;
+        current_call_frame.memory.store_bytes(
+            dest_offset,
+            &bytecode[offset
+                ..offset
+                    .checked_add(size)
+                    .ok_or(VMError::MemoryLoadOutOfBounds)?],
+        )?;
 
         Ok(OpcodeSuccess::Continue)
     }
@@ -392,9 +417,11 @@ impl VM {
             .unwrap_or(usize::MAX);
 
         let minimum_word_size = (size + WORD_SIZE - 1) / WORD_SIZE;
-        let memory_expansion_cost = current_call_frame
-            .memory
-            .expansion_cost(dest_offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?)?;
+        let memory_expansion_cost = current_call_frame.memory.expansion_cost(
+            dest_offset
+                .checked_add(size)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?,
+        )?;
         let gas_cost = gas_cost::RETURNDATACOPY_STATIC
             + gas_cost::RETURNDATACOPY_DYNAMIC_BASE * minimum_word_size
             + memory_expansion_cost;
@@ -407,9 +434,13 @@ impl VM {
 
         let sub_return_data_len = current_call_frame.sub_return_data.len();
         let data = if returndata_offset < sub_return_data_len {
-            current_call_frame
-                .sub_return_data
-                .slice(returndata_offset..(returndata_offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?).min(sub_return_data_len))
+            current_call_frame.sub_return_data.slice(
+                returndata_offset
+                    ..(returndata_offset
+                        .checked_add(size)
+                        .ok_or(VMError::MemoryLoadOutOfBounds)?)
+                    .min(sub_return_data_len),
+            )
         } else {
             vec![0u8; size].into()
         };

--- a/crates/vm/levm/src/opcode_handlers/keccak.rs
+++ b/crates/vm/levm/src/opcode_handlers/keccak.rs
@@ -27,7 +27,7 @@ impl VM {
             .unwrap_or(usize::MAX);
 
         let minimum_word_size = (size + WORD_SIZE - 1) / WORD_SIZE;
-        let memory_expansion_cost = current_call_frame.memory.expansion_cost(offset + size)?;
+        let memory_expansion_cost = current_call_frame.memory.expansion_cost(offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?)?;
         let gas_cost = gas_cost::KECCAK25_STATIC
             + gas_cost::KECCAK25_DYNAMIC_BASE * minimum_word_size
             + memory_expansion_cost;

--- a/crates/vm/levm/src/opcode_handlers/keccak.rs
+++ b/crates/vm/levm/src/opcode_handlers/keccak.rs
@@ -27,7 +27,11 @@ impl VM {
             .unwrap_or(usize::MAX);
 
         let minimum_word_size = (size + WORD_SIZE - 1) / WORD_SIZE;
-        let memory_expansion_cost = current_call_frame.memory.expansion_cost(offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?)?;
+        let memory_expansion_cost = current_call_frame.memory.expansion_cost(
+            offset
+                .checked_add(size)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?,
+        )?;
         let gas_cost = gas_cost::KECCAK25_STATIC
             + gas_cost::KECCAK25_DYNAMIC_BASE * minimum_word_size
             + memory_expansion_cost;

--- a/crates/vm/levm/src/opcode_handlers/logging.rs
+++ b/crates/vm/levm/src/opcode_handlers/logging.rs
@@ -41,7 +41,11 @@ impl VM {
             topics.push(H256::from_slice(&topic_bytes));
         }
 
-        let memory_expansion_cost = current_call_frame.memory.expansion_cost(offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?)?;
+        let memory_expansion_cost = current_call_frame.memory.expansion_cost(
+            offset
+                .checked_add(size)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?,
+        )?;
         let gas_cost = gas_cost::LOGN_STATIC
             + gas_cost::LOGN_DYNAMIC_BASE * number_of_topics
             + gas_cost::LOGN_DYNAMIC_BYTE_BASE * size

--- a/crates/vm/levm/src/opcode_handlers/logging.rs
+++ b/crates/vm/levm/src/opcode_handlers/logging.rs
@@ -23,7 +23,7 @@ impl VM {
         }
 
         let number_of_topics = (op as u8) - (Opcode::LOG0 as u8);
-        let offset = current_call_frame
+        let offset: usize = current_call_frame
             .stack
             .pop()?
             .try_into()
@@ -41,7 +41,7 @@ impl VM {
             topics.push(H256::from_slice(&topic_bytes));
         }
 
-        let memory_expansion_cost = current_call_frame.memory.expansion_cost(offset + size)?;
+        let memory_expansion_cost = current_call_frame.memory.expansion_cost(offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?)?;
         let gas_cost = gas_cost::LOGN_STATIC
             + gas_cost::LOGN_DYNAMIC_BASE * number_of_topics
             + gas_cost::LOGN_DYNAMIC_BYTE_BASE * size

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -98,7 +98,7 @@ impl VM {
         let mut value_bytes = [0u8; WORD_SIZE];
         value.to_big_endian(&mut value_bytes);
 
-        current_call_frame.memory.store_bytes(offset, &value_bytes);
+        current_call_frame.memory.store_bytes(offset, &value_bytes)?;
 
         Ok(OpcodeSuccess::Continue)
     }
@@ -120,7 +120,7 @@ impl VM {
 
         current_call_frame
             .memory
-            .store_bytes(offset, value_bytes[WORD_SIZE - 1..WORD_SIZE].as_ref());
+            .store_bytes(offset, value_bytes[WORD_SIZE - 1..WORD_SIZE].as_ref())?;
 
         Ok(OpcodeSuccess::Continue)
     }
@@ -281,7 +281,7 @@ impl VM {
         if size > 0 {
             current_call_frame
                 .memory
-                .copy(src_offset, dest_offset, size);
+                .copy(src_offset, dest_offset, size)?;
         }
 
         Ok(OpcodeSuccess::Continue)

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -64,9 +64,11 @@ impl VM {
             .pop()?
             .try_into()
             .unwrap_or(usize::MAX);
-        let memory_expansion_cost = current_call_frame
-            .memory
-            .expansion_cost(offset.checked_add(WORD_SIZE).ok_or(VMError::OverflowInArithmeticOp)?)?;
+        let memory_expansion_cost = current_call_frame.memory.expansion_cost(
+            offset
+                .checked_add(WORD_SIZE)
+                .ok_or(VMError::OverflowInArithmeticOp)?,
+        )?;
         let gas_cost = gas_cost::MLOAD_STATIC + memory_expansion_cost;
 
         self.increase_consumed_gas(current_call_frame, gas_cost)?;
@@ -87,9 +89,11 @@ impl VM {
             .pop()?
             .try_into()
             .map_err(|_err| VMError::VeryLargeNumber)?;
-        let memory_expansion_cost = current_call_frame
-            .memory
-            .expansion_cost(offset.checked_add(WORD_SIZE).ok_or(VMError::OverflowInArithmeticOp)?)?;
+        let memory_expansion_cost = current_call_frame.memory.expansion_cost(
+            offset
+                .checked_add(WORD_SIZE)
+                .ok_or(VMError::OverflowInArithmeticOp)?,
+        )?;
         let gas_cost = gas_cost::MSTORE_STATIC + memory_expansion_cost;
 
         self.increase_consumed_gas(current_call_frame, gas_cost)?;
@@ -98,7 +102,9 @@ impl VM {
         let mut value_bytes = [0u8; WORD_SIZE];
         value.to_big_endian(&mut value_bytes);
 
-        current_call_frame.memory.store_bytes(offset, &value_bytes)?;
+        current_call_frame
+            .memory
+            .store_bytes(offset, &value_bytes)?;
 
         Ok(OpcodeSuccess::Continue)
     }
@@ -109,7 +115,11 @@ impl VM {
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeSuccess, VMError> {
         let offset: usize = current_call_frame.stack.pop()?.try_into().unwrap();
-        let memory_expansion_cost = current_call_frame.memory.expansion_cost(offset.checked_add(1).ok_or(VMError::OverflowInArithmeticOp)?)?;
+        let memory_expansion_cost = current_call_frame.memory.expansion_cost(
+            offset
+                .checked_add(1)
+                .ok_or(VMError::OverflowInArithmeticOp)?,
+        )?;
         let gas_cost = gas_cost::MSTORE8_STATIC + memory_expansion_cost;
 
         self.increase_consumed_gas(current_call_frame, gas_cost)?;

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -66,7 +66,7 @@ impl VM {
             .unwrap_or(usize::MAX);
         let memory_expansion_cost = current_call_frame
             .memory
-            .expansion_cost(offset + WORD_SIZE)?;
+            .expansion_cost(offset.checked_add(WORD_SIZE).ok_or(VMError::OverflowInArithmeticOp)?)?;
         let gas_cost = gas_cost::MLOAD_STATIC + memory_expansion_cost;
 
         self.increase_consumed_gas(current_call_frame, gas_cost)?;
@@ -82,14 +82,14 @@ impl VM {
         &mut self,
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeSuccess, VMError> {
-        let offset = current_call_frame
+        let offset: usize = current_call_frame
             .stack
             .pop()?
             .try_into()
             .map_err(|_err| VMError::VeryLargeNumber)?;
         let memory_expansion_cost = current_call_frame
             .memory
-            .expansion_cost(offset + WORD_SIZE)?;
+            .expansion_cost(offset.checked_add(WORD_SIZE).ok_or(VMError::OverflowInArithmeticOp)?)?;
         let gas_cost = gas_cost::MSTORE_STATIC + memory_expansion_cost;
 
         self.increase_consumed_gas(current_call_frame, gas_cost)?;
@@ -108,8 +108,8 @@ impl VM {
         &mut self,
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeSuccess, VMError> {
-        let offset = current_call_frame.stack.pop()?.try_into().unwrap();
-        let memory_expansion_cost = current_call_frame.memory.expansion_cost(offset + 1)?;
+        let offset: usize = current_call_frame.stack.pop()?.try_into().unwrap();
+        let memory_expansion_cost = current_call_frame.memory.expansion_cost(offset.checked_add(1).ok_or(VMError::OverflowInArithmeticOp)?)?;
         let gas_cost = gas_cost::MSTORE8_STATIC + memory_expansion_cost;
 
         self.increase_consumed_gas(current_call_frame, gas_cost)?;

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -1,5 +1,8 @@
 use crate::{
-    call_frame::CallFrame, constants::{call_opcode, gas_cost, SUCCESS_FOR_RETURN}, errors::{OpcodeSuccess, ResultReason, VMError}, vm::{word_to_address, VM}
+    call_frame::CallFrame,
+    constants::{call_opcode, gas_cost, SUCCESS_FOR_RETURN},
+    errors::{OpcodeSuccess, ResultReason, VMError},
+    vm::{word_to_address, VM},
 };
 use ethereum_rust_core::{types::TxKind, U256};
 
@@ -40,7 +43,14 @@ impl VM {
             return Err(VMError::OpcodeNotAllowedInStaticContext);
         }
 
-        let memory_byte_size = (args_offset.checked_add(args_size).ok_or(VMError::MemoryLoadOutOfBounds)?).max(ret_offset.checked_add(ret_size).ok_or(VMError::MemoryLoadOutOfBounds)?);
+        let memory_byte_size = (args_offset
+            .checked_add(args_size)
+            .ok_or(VMError::MemoryLoadOutOfBounds)?)
+        .max(
+            ret_offset
+                .checked_add(ret_size)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?,
+        );
         let memory_expansion_cost = current_call_frame.memory.expansion_cost(memory_byte_size)?;
 
         let positive_value_cost = if !value.is_zero() {
@@ -121,12 +131,13 @@ impl VM {
             .map_err(|_err| VMError::VeryLargeNumber)?;
 
         let memory_byte_size = args_offset
-        .checked_add(args_size)
-        .and_then(|src_sum| {
-            ret_offset
-                .checked_add(ret_size)
-                .map(|dest_sum| src_sum.max(dest_sum))
-        }).ok_or(VMError::OverflowInArithmeticOp)?;
+            .checked_add(args_size)
+            .and_then(|src_sum| {
+                ret_offset
+                    .checked_add(ret_size)
+                    .map(|dest_sum| src_sum.max(dest_sum))
+            })
+            .ok_or(VMError::OverflowInArithmeticOp)?;
         let memory_expansion_cost = current_call_frame.memory.expansion_cost(memory_byte_size)?;
 
         let gas_cost = memory_expansion_cost;
@@ -169,7 +180,11 @@ impl VM {
             .try_into()
             .unwrap_or(usize::MAX);
 
-        let gas_cost = current_call_frame.memory.expansion_cost(offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?)?;
+        let gas_cost = current_call_frame.memory.expansion_cost(
+            offset
+                .checked_add(size)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?,
+        )?;
 
         self.increase_consumed_gas(current_call_frame, gas_cost)?;
 
@@ -217,12 +232,13 @@ impl VM {
         let is_static = current_call_frame.is_static;
 
         let memory_byte_size = args_offset
-        .checked_add(args_size)
-        .and_then(|src_sum| {
-            ret_offset
-                .checked_add(ret_size)
-                .map(|dest_sum| src_sum.max(dest_sum))
-        }).ok_or(VMError::OverflowInArithmeticOp)?;
+            .checked_add(args_size)
+            .and_then(|src_sum| {
+                ret_offset
+                    .checked_add(ret_size)
+                    .map(|dest_sum| src_sum.max(dest_sum))
+            })
+            .ok_or(VMError::OverflowInArithmeticOp)?;
         let memory_expansion_cost = current_call_frame.memory.expansion_cost(memory_byte_size)?;
 
         let gas_cost = memory_expansion_cost;
@@ -278,12 +294,13 @@ impl VM {
         let to = code_address; // In this case code_address and the sub-context account are the same. Unlike CALLCODE or DELEGATECODE.
 
         let memory_byte_size = args_offset
-        .checked_add(args_size)
-        .and_then(|src_sum| {
-            ret_offset
-                .checked_add(ret_size)
-                .map(|dest_sum| src_sum.max(dest_sum))
-        }).ok_or(VMError::OverflowInArithmeticOp)?;
+            .checked_add(args_size)
+            .and_then(|src_sum| {
+                ret_offset
+                    .checked_add(ret_size)
+                    .map(|dest_sum| src_sum.max(dest_sum))
+            })
+            .ok_or(VMError::OverflowInArithmeticOp)?;
         let memory_expansion_cost = current_call_frame.memory.expansion_cost(memory_byte_size)?;
 
         let gas_cost = memory_expansion_cost;
@@ -358,7 +375,11 @@ impl VM {
 
         let size = current_call_frame.stack.pop()?.as_usize();
 
-        let gas_cost = current_call_frame.memory.expansion_cost(offset.checked_add(size).ok_or(VMError::MemoryLoadOutOfBounds)?)?;
+        let gas_cost = current_call_frame.memory.expansion_cost(
+            offset
+                .checked_add(size)
+                .ok_or(VMError::MemoryLoadOutOfBounds)?,
+        )?;
 
         self.increase_consumed_gas(current_call_frame, gas_cost)?;
 

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -100,4 +100,5 @@ pub fn new_vm_with_ops_addr_bal_db(
         Arc::new(db),
         cache,
     )
+    .unwrap()
 }

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -506,6 +506,7 @@ impl VM {
         ret_offset: usize,
         ret_size: usize,
     ) -> Result<OpcodeSuccess, VMError> {
+        println!("Inside generic call");
         let mut sender_account = self.get_account(&current_call_frame.msg_sender);
 
         if sender_account.info.balance < value {
@@ -555,9 +556,10 @@ impl VM {
         );
 
         // TODO: Increase this to 1024
-        if new_call_frame.depth > 100 {
+        if new_call_frame.depth > 10 {
             current_call_frame.stack.push(U256::from(REVERT_FOR_CALL))?;
-            return Ok(OpcodeSuccess::Result(ResultReason::Revert));
+            // return Ok(OpcodeSuccess::Result(ResultReason::Revert));
+            return Err(VMError::OutOfGas); // This is wrong but it is for testing purposes.
         }
 
         current_call_frame.sub_return_data_offset = ret_offset;
@@ -575,7 +577,7 @@ impl VM {
         current_call_frame.logs.extend(tx_report.logs);
         current_call_frame
             .memory
-            .store_n_bytes(ret_offset, &tx_report.output, ret_size);
+            .store_n_bytes(ret_offset, &tx_report.output, ret_size)?;
         current_call_frame.sub_return_data = tx_report.output;
 
         // What to do, depending on TxResult
@@ -640,7 +642,7 @@ impl VM {
         salt: Option<U256>,
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeSuccess, VMError> {
-        
+        return Err(VMError::OutOfGas);
 
         let code_size_in_memory = code_size_in_memory
             .try_into()

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -555,7 +555,7 @@ impl VM {
         );
 
         // TODO: Increase this to 1024
-        if new_call_frame.depth > 257 {
+        if new_call_frame.depth > 100 {
             current_call_frame.stack.push(U256::from(REVERT_FOR_CALL))?;
             return Ok(OpcodeSuccess::Result(ResultReason::Revert));
         }
@@ -640,6 +640,8 @@ impl VM {
         salt: Option<U256>,
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeSuccess, VMError> {
+        
+
         let code_size_in_memory = code_size_in_memory
             .try_into()
             .map_err(|_err| VMError::VeryLargeNumber)?;

--- a/crates/vm/levm/tests/tests.rs
+++ b/crates/vm/levm/tests/tests.rs
@@ -4011,7 +4011,8 @@ fn caller_op() {
         Default::default(),
         Arc::new(db),
         cache,
-    );
+    )
+    .unwrap();
 
     let mut current_call_frame = vm.call_frames.pop().unwrap();
     vm.execute(&mut current_call_frame);
@@ -4051,7 +4052,8 @@ fn origin_op() {
         Default::default(),
         Arc::new(db),
         cache,
-    );
+    )
+    .unwrap();
 
     let mut current_call_frame = vm.call_frames.pop().unwrap();
     vm.execute(&mut current_call_frame);
@@ -4117,7 +4119,8 @@ fn address_op() {
         Default::default(),
         Arc::new(db),
         cache,
-    );
+    )
+    .unwrap();
     let mut current_call_frame = vm.call_frames.pop().unwrap();
     vm.execute(&mut current_call_frame);
 
@@ -4160,7 +4163,8 @@ fn selfbalance_op() {
         Default::default(),
         Arc::new(db),
         cache,
-    );
+    )
+    .unwrap();
     let mut current_call_frame = vm.call_frames.pop().unwrap();
     vm.execute(&mut current_call_frame);
 
@@ -4197,7 +4201,8 @@ fn callvalue_op() {
         Default::default(),
         Arc::new(db),
         cache,
-    );
+    )
+    .unwrap();
 
     let mut current_call_frame = vm.call_frames.pop().unwrap();
     vm.execute(&mut current_call_frame);
@@ -4234,7 +4239,8 @@ fn codesize_op() {
         Default::default(),
         Arc::new(db),
         cache,
-    );
+    )
+    .unwrap();
 
     let mut current_call_frame = vm.call_frames.pop().unwrap();
     vm.execute(&mut current_call_frame);
@@ -4273,7 +4279,8 @@ fn gasprice_op() {
         Default::default(),
         Arc::new(db),
         cache,
-    );
+    )
+    .unwrap();
 
     let mut current_call_frame = vm.call_frames.pop().unwrap();
     vm.execute(&mut current_call_frame);
@@ -4328,7 +4335,8 @@ fn codecopy_op() {
         Default::default(),
         Arc::new(db),
         cache,
-    );
+    )
+    .unwrap();
 
     let mut current_call_frame = vm.call_frames.pop().unwrap();
     vm.execute(&mut current_call_frame);

--- a/crates/vm/levm/tests/tests.rs
+++ b/crates/vm/levm/tests/tests.rs
@@ -1792,7 +1792,7 @@ fn nested_calls() {
     let success = current_call_frame.stack.pop().unwrap();
     assert_eq!(success, U256::one());
 
-    let ret_offset = 0;
+    let ret_offset: usize = 0;
     let ret_size = 64;
     let return_data = current_call_frame
         .sub_return_data


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
- The objective is to run ef tests without panicking, so that they don't interrupt execution.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Some reasons tests panicked:
- Trying to resize memory to a very high number that the system doesn't tolerate
   - This was fixed by just resizing only if the gas limit allows it. The EVM doesn't have a "max" memory size, this max is limited by the gas avaiable. Opcodes that didn't have gas implemented were a problem so I partially implemented gas costs for them, just for their memory expansion cost.
- Trying to add with overflow 
   - For this error normal addition was replaced for `checked_add` and returned an error if it overflowed.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

