### PR TITLE
feat(l2): initial state pruned trie in zkVM program

### DIFF
--- a/crates/l2/prover/zkvm/interface/Cargo.toml
+++ b/crates/l2/prover/zkvm/interface/Cargo.toml
@@ -3,19 +3,6 @@ name = "zkvm_interface"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-thiserror = "1.0.64"
-
-ethereum_rust-storage = { path = "../../../../storage/store" }
-
-# revm
-revm = { version = "14.0.3", features = [
-    "std",
-    "serde",
-    "kzg-rs",
-], default-features = false }
-
 [build-dependencies]
 risc0-build = { version = "1.1.2" }
 


### PR DESCRIPTION
**Motivation**

.

**Description**

- moved zkVM program input structure into interface and modified it into `ProgramInput` (because the zkvm program fails to build when importing the `prover` crate)
