### PR TITLE
fix(levm): remove implicit as conversions

### DIFF
--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -133,16 +133,20 @@ impl CallFrame {
     }
 
     /// Jump to the given address, returns false if the jump position wasn't a JUMPDEST
-    pub fn jump(&mut self, jump_address: U256) -> bool {
-        if !self.valid_jump(jump_address) {
-            return false;
+    pub fn jump(&mut self, jump_address: U256) -> Result<bool, VMError> {
+        let jump_address_usize = jump_address
+            .try_into()
+            .map_err(|_err| VMError::VeryLargeNumber)?;
+
+        if !self.valid_jump(jump_address_usize) {
+            return Ok(false);
         }
-        self.pc = jump_address.as_usize();
-        true
+        self.pc = jump_address_usize;
+        Ok(true)
     }
 
-    fn valid_jump(&self, jump_address: U256) -> bool {
-        self.opcode_at(jump_address.as_usize())
+    fn valid_jump(&self, jump_address: usize) -> bool {
+        self.opcode_at(jump_address)
             .map(|opcode| opcode.eq(&Opcode::JUMPDEST))
             .is_some_and(|is_jumpdest| is_jumpdest)
     }

--- a/crates/vm/levm/src/opcode_handlers/arithmetic.rs
+++ b/crates/vm/levm/src/opcode_handlers/arithmetic.rs
@@ -245,7 +245,12 @@ impl VM {
 
         let byte_size = byte_size.min(U256::from(max_byte_size));
         let sign_bit_index = bits_per_byte * byte_size + sign_bit_position_on_byte;
-        let is_negative = value_to_extend.bit(sign_bit_index.as_usize());
+
+        let sign_bit_index_usize: usize = sign_bit_index
+            .try_into()
+            .map_err(|_err| VMError::VeryLargeNumber)?;
+        let is_negative = value_to_extend.bit(sign_bit_index_usize);
+
         let sign_bit_mask = (U256::one() << sign_bit_index) - U256::one();
         let result = if is_negative {
             value_to_extend | !sign_bit_mask

--- a/crates/vm/levm/src/opcode_handlers/block.rs
+++ b/crates/vm/levm/src/opcode_handlers/block.rs
@@ -34,7 +34,9 @@ impl VM {
             return Ok(OpcodeSuccess::Continue);
         }
 
-        let block_number = block_number.as_u64();
+        let block_number: u64 = block_number
+            .try_into()
+            .map_err(|_err| VMError::VeryLargeNumber)?;
 
         if let Some(block_hash) = self.db.get_block_hash(block_number) {
             current_call_frame
@@ -161,7 +163,11 @@ impl VM {
     ) -> Result<OpcodeSuccess, VMError> {
         self.increase_consumed_gas(current_call_frame, gas_cost::BLOBHASH)?;
 
-        let index = current_call_frame.stack.pop()?.as_usize();
+        let index: usize = current_call_frame
+            .stack
+            .pop()?
+            .try_into()
+            .map_err(|_err| VMError::VeryLargeNumber)?;
 
         let blob_hash: H256 = match &self.env.tx_blob_hashes {
             Some(vec) => match vec.get(index) {

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -344,7 +344,7 @@ impl VM {
         self.increase_consumed_gas(current_call_frame, gas_cost::JUMP)?;
 
         let jump_address = current_call_frame.stack.pop()?;
-        if !current_call_frame.jump(jump_address) {
+        if !current_call_frame.jump(jump_address)? {
             return Err(VMError::InvalidJump);
         }
 
@@ -359,7 +359,7 @@ impl VM {
         let jump_address = current_call_frame.stack.pop()?;
         let condition = current_call_frame.stack.pop()?;
 
-        if condition != U256::zero() && !current_call_frame.jump(jump_address) {
+        if condition != U256::zero() && !current_call_frame.jump(jump_address)? {
             return Err(VMError::InvalidJump);
         }
 

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -369,16 +369,16 @@ impl VM {
         //      The actual reversion of changes is made in the execute() function.
 
         let offset: usize = current_call_frame
-        .stack
-        .pop()?
-        .try_into()
-        .map_err(|_err| VMError::VeryLargeNumber)?;
+            .stack
+            .pop()?
+            .try_into()
+            .map_err(|_err| VMError::VeryLargeNumber)?;
 
         let size = current_call_frame
-        .stack
-        .pop()?
-        .try_into()
-        .map_err(|_err| VMError::VeryLargeNumber)?;
+            .stack
+            .pop()?
+            .try_into()
+            .map_err(|_err| VMError::VeryLargeNumber)?;
 
         let gas_cost = current_call_frame.memory.expansion_cost(
             offset

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -368,9 +368,17 @@ impl VM {
         // Notes:
         //      The actual reversion of changes is made in the execute() function.
 
-        let offset = current_call_frame.stack.pop()?.as_usize();
+        let offset: usize = current_call_frame
+        .stack
+        .pop()?
+        .try_into()
+        .map_err(|_err| VMError::VeryLargeNumber)?;
 
-        let size = current_call_frame.stack.pop()?.as_usize();
+        let size = current_call_frame
+        .stack
+        .pop()?
+        .try_into()
+        .map_err(|_err| VMError::VeryLargeNumber)?;
 
         let gas_cost = current_call_frame.memory.expansion_cost(
             offset


### PR DESCRIPTION
**Motivation**

We have recently removed as conversions because they panicked, but there were left some implicit conversions left.

**Description**

This is done by using `.try_into()` and then maping the error to a `VMError::VeryLargeNumber`

