### PR TITLE
feat(levm): add padding at push 

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/push.rs
+++ b/crates/vm/levm/src/opcode_handlers/push.rs
@@ -25,7 +25,10 @@ impl VM {
             .checked_add(1)
             .ok_or(VMError::InvalidOpcode)?;
 
-        let mut readed_n_bytes: Vec<u8> = current_call_frame.bytecode[current_call_frame.pc..]
+        let mut readed_n_bytes: Vec<u8> = current_call_frame
+            .bytecode
+            .get(current_call_frame.pc()..)
+            .ok_or(VMError::InvalidBytecode)?
             .iter()
             .take(n_bytes)
             .cloned()
@@ -33,7 +36,13 @@ impl VM {
 
         // If I have fewer bytes to read than I need, I add as many leading 0s as necessary
         if readed_n_bytes.len() < n_bytes {
-            let padding = vec![0; n_bytes - readed_n_bytes.len()];
+            let gap_to_fill =
+                n_bytes
+                    .checked_sub(readed_n_bytes.len())
+                    .ok_or(VMError::Internal(
+                        InternalError::ArithmeticOperationUnderflow,
+                    ))?;
+            let padding = vec![0; gap_to_fill];
             readed_n_bytes.splice(0..0, padding);
         }
 


### PR DESCRIPTION
**Motivation**

This fixes an error that happens when Push is the last instruction and there are not enough bytes to cover the needed. 

**Description**

In that case, we fill the empty space putting zeros at left. This bug was found when debugging randomStatetest0 of the EF Tests