### PR TITLE
fix(l2): fix zkVM performance test

### DIFF
--- a/.github/workflows/l2_prover_ci.yaml
+++ b/.github/workflows/l2_prover_ci.yaml
@@ -2,12 +2,8 @@ name: L2 Prover CI
 on:
   push:
     branches: ["main"]
-    paths:
-      - "crates/l2/prover/**"
   pull_request:
     branches: ["**"]
-    paths:
-      - "crates/l2/prover/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/crates/l2/prover/tests/perf_zkvm.rs
+++ b/crates/l2/prover/tests/perf_zkvm.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 use tracing::info;
 
 use ethereum_rust_blockchain::add_block;
@@ -11,15 +11,10 @@ use ethereum_rust_vm::execution_db::ExecutionDB;
 async fn test_performance_zkvm() {
     tracing_subscriber::fmt::init();
 
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    // Go back 3 levels (Go to the root of the project)
-    for _ in 0..3 {
-        path.pop();
-    }
-    path.push("test_data");
+    let mut path = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../../../test_data"));
 
     // Another use is genesis-execution-api.json in conjunction with chain.rlp(20 blocks not too loaded).
-    let genesis_file_path = path.join("genesis-l2.json");
+    let genesis_file_path = path.join("genesis-l2-old.json");
     // l2-loadtest.rlp has blocks with many txs.
     let chain_file_path = path.join("l2-loadtest.rlp");
 

--- a/test_data/genesis-l2-old.json
+++ b/test_data/genesis-l2-old.json
@@ -1,0 +1,548 @@
+{
+  "config": {
+    "chainId": 1729,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "mergeNetsplitBlock": 0,
+    "terminalTotalDifficulty": 0,
+    "terminalTotalDifficultyPassed": true,
+    "shanghaiTime": 0,
+    "cancunTime": 0,
+    "pragueTime": 1718232101
+  },
+  "alloc": {
+    "0x0007a881CD95B1484fca47615B64803dad620C8d": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0000bd19F707CA481886244bDd20Bd6B8a81bd3e": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000",
+      "nonce": "0"
+    },
+    "0x000cD1537A823Ae7609E3897DA8d95801B557a8a": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0006d77295a0260ceAC113c5Aa15CFf0d28d9723": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000eA2e72065A2ceCA7f677Bc5E648279c2D843d": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000a52D537c4150ec274dcE3962a0d179B7E71B0": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0009aEFF154De37C8e02E83f93D2FeC5EC96f8a3": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000f1EB7F258D4A7683E5D0FC3C01058841DDC6f": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000aC79590dCc656c00c4453f123AcBf10DBb086": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0002Bf507275217c9E5EE250bC1B5ca177bb4f74": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000a3fC3BFD55b37025E6F4f57B0B6121F54e5bF": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000b4C43cce938dfD3420F975591Ee46D872C136": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0004b0C6de796fD980554cc7ff7B062b3B5079E1": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00025eea83bA285532F5054b238c938076833d13": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000352E93fe11f9B715fdc61864315970B3DC082": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000c0d6b7C4516a5B274C51EA331A9410fe69127": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000D06C23EeD09A7Fa81cADd7eD5C783E8a25635": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0003Ea7fDFCdb89E9ddAb0128ec5C628F8D09D45": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0005C34d7B8b06CE8019C3Bb232dE82B2748A560": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00079f33619F70F1DCE64EB6782E45D3498d807C": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0003E72436Ff296B3d39339784499D021b72Aca5": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00075af7E665F3Ca4A4b05520CD6d5c13BbFEAf8": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000b59AeD48ADCd6c36Ae5f437AbB9CA730a2c43": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0004e4dfCed9d798767A4d7BA2B03495cE80A2b7": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000e73282F60E2CdE0D4FA9B323B6D54d860f330": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00010AB05661Bfde304A4d884DF99d3011A83C54": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000B9Ea41A9dF00b7ae597afc0D10AF42666081F": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00087C666bf7f52758DE186570979C4C79747157": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0008a52c83D34f0791D07FfeD04Fb6b14f94E2D4": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000A7Bbde38Fc53925D0De9cc1beE3038d36c2d2": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000Aa0154ed6560257d222B5dbE6ce4b66c48979": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000b681738e1f8aF387c41b2b1f0A04E0C33e9DB": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000D66A7706f2DD5F557d5b68e01E07E8FFDfaf5": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00069DA530A71Dc92D02090d7f5f63e326e9beD0": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000db74a3da16609F183ACE7AF65B43D896349CE": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0003B1aB565508e095a543C89531e3fbc4a349DA": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0001c94c108BcE19CDb36b00F867A1798A81DedA": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000995137728C7C2a9142F4628f95c98Cac433d7": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000Ec60762AD0425A04C40c118Db5B9710Aa639e": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000Ebf88AE1BA960B06b0a9bbE576baa3B72E92E": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000e1a554572dd96fF3d1F2664832F3E4a66E7b7": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00032C03f3b02D816128Fb5D2752398E2919a03c": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000A073dAC5ec2058a0De0e175874D5E297E086E": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000e06626Bb8618D9A1867362D46ddb1bF95ad75": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000212949b4866db43bAF7c4e0975426710ED081": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00094cc0653B52406170105F4eb96C5e2f31Ab74": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000E67E4b1A23A3826304099cb24f337c916CF4b": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000885A4932ebeD6D760EA381e4EdAe51A53db05": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000883A40409Fa2193b698928459CB9E4DD5f8D8": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0002590DD45738F909115B163F1322A8A24a8B4E": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0005f132597da3152a6Da6beDB7C10bcC9B1B7f5": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00031470def99c1d4dfE1fd08DD7A8520Ce21DB7": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0001Ebe3a3bA36f57F5989B3F0e5BEEBc710569C": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0006Bd0469166f63D0A1c33F71898D2b2E009b9b": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00000A8d3f37af8DeF18832962Ee008d8dCa4F7b": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000e490f26249951F8527779399aa8F281509aC0": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0000638374f7dB166990BDc6aBeE884Ee01a8920": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00031dE95353DeE86dc9B1248e825500DE0B39aF": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000511B42328794337D8b6846E5cFFef30c2d77A": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000d0576AdEf7083d53F6676bfc7c30d03b6Db1B": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0001E8Ff6406a7cd9071F46B8255Db6C16178448": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000C47c771A8db282eC233b28AD8525dc74D13FE": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000798832bb08268dB237898b95A8DaE9D58b62c": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000c877a5D9b9De61e5318B3f4330c56ecdC0865": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0003Ffc1f09d39FBFE87eD63E98249039C7b1d9A": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000d72403c18B2516d8ada074E1E7822bF1084DB": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00054e17Db8C8Db028B19cB0f631888AdEb35E4b": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0002d9b2a816717C4d70040D66A714795F9B27a4": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0002AfCC1B0B608E86b5a1Dc45dE08184E629796": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000b1db69627F04688aA47951d847c8BFAB3fFaE": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000c2de896E4a92e796d6A9c1E4B01feB3e6Ed61": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000EDC52118DadB4B81f013005b6db2665B682ac": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0009e10C0D2F1a7A2b00b61c476aa8b608c60aDc": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000f2AbaA7581fAA2ad5C82b604C77ef68c3eAD9": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000F74AA6EE08C15076b3576eE33Ed3a80c9A1AD": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0001533C6C5b425815b2BaDdCdd42DFF3be04BCb": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0002D79686DeF20a0aB43FEA4a41a1Ad56529621": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00077A336FCA40F933a7A301F4a39C26594F3EB5": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000B05E15C62CBC266A4DD1804b017d1f6dB078b": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000130badE00212bE1AA2F4aCFe965934635C9cD": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0008Bd31Ee6A758e168844cBEA107Ca4d87251aF": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000A390975F21371F1Cf3C783a4A7C1aF49074Fe": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000701F7d594Fb146e4d1c71342012e48A788055": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0005c6BeD054FEad199D72C6f663fC6fBf996153": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0009d862F87F26c638AAd14F2cc48FCa54DBf49d": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00029637dA962294449549f804f8184046F5fbB0": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000279CB54E00B858774afEA4601034Db41c1A05": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0003dDe6f01e3B755e24891a5B0f2463BaD83e15": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000086Eeea461Ca48e4D319F9789F3Efd134E574": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0004351AD413792131011CC7ed8299dd783C6487": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00097B4463159340Ac83B9bdf657C304cD70c11c": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0004ad0D0823e3d31C6ECA2A3495373fA76c43aC": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0005E815c1A3F40011Bd70C76062bbcBc51c546B": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0006A070bAC6195b59d4bC7f73741DCBe4e16b5e": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0006cEE23d8E9BC8d99E826cDa50481394aD9bDD": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000a523148845bEe3EE1e9F83df8257a1191C85B": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000D268F322F10925cdB5d2AD527E582259Da655": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000E5DE0a0175866d21F4Ec6c41F0422A05f14D6": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000cDF8Dba2393a40857cbCB0FCD9b998a941078": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000A341763112a5E3452c7AEE45c382a3fb7dc78": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000635BCbB109781Cea0Cd53e9f1370Dbac9937f": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000E0ea540095B3853c4cb09E5Cdd197330D3B55": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00044cbfb4Ef6054667994C37c0fe0B6BB639718": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00065fC4337dF331242bEE738031dAf35817Ee9e": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000815A8A659a51A8EF01F02441947Ea99182568": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0004C8da21c68dED2F63efD9836De7D43e7cDa10": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0006ed38815a9439c59bD917c12f77a9A7D39BCE": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0004Aa0442d0d43222431b3017912EC6a099771C": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000b3F6da04b6261B4154C8FaEd119632C49DBd5": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000AEBc2568796FDB763CAB67B31e0feE58Fe17d": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000425E97fC6692891876012824a210451cC06C4": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000036e0f87f8Cd3e97f9cfDB2e4E5Ff193c217a": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000305CD7184aB37fdd3D826B92A640218D09527": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000c95f1D83De53B76a0828F1bCdB1DfE12C0ab3": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000882c5FbD315801e4C367BCB04dBD299B9F571": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0000E101815A78EbB9FBBa34F4871aD32d5eb6CD": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000A997c1ceCB1DA78C16249e032e77d1865646a": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00056bde49E3cAA9166C2a4C4951d0Cf067956A0": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000e65342176C7dac47bc75113F569695d6A113C": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0008D608884cd733642ab17aCa0c8504850B94fA": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000dFE27e1b71a49B641ad762aB95558584878D1": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00085D9D1a71acf1080cED44CB501B350900627f": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0007d272a1f7Dfe862b030adE2922D149f3bDe3B": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0004b230511F921934F33E8B4425E43295232680": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0007514395022786B59ff91408692462C48d872c": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0005b34eB0d99dE72DB14d466f692009c4049D46": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0001a2c749FE0Ab1C09f1131BA17530f9D764fBC": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000c6c1D8F778D981968F9904772B0c455E1C17c": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000e64e0a2Fd76B4883c800833c82c5F2420b813": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000577bDc84B4019F77D9D09BDD8ED6145E0e890": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000029bD811D292E7f1CF36c0FA08fd753C45074": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000cE6740261E297FaD4c975D6D8F89f95C29add": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0001d0bAE8B1B9fe61d0B788E562A987813cbD98": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000E3388598A0534275104Ad44745620AF31EC7E": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000791D3185781e14eBb342E5df3BC9910f62E6F": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000Df55E76cf6dfD9598DD2b54948dE937f50f2B": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000055acf237931902ceBf4B905BF59813180555": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00009074D8fc5Eeb25f1548Df05AD955E21FB08D": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000C1aE5FeCf09595C0C76Db609FEB2a5Af0962E": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000F76B2Fe7cCC13474de28586A877664EBA16B4": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000F7cFBa0B176Afc2eBadA9d4764d2eA6BBC5a1": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00002132cE94eEfB06eB15898C1AABd94feb0AC2": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00069dC0cc6b9d7B48B5348b12F625E8aB704104": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000A0191cf913E03bd594bC8817FC3B2895C0a25": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0007316aEDc52EB35c9B5c2E44e9fD712d1DF887": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000EBd066B6FEBB9d7f3B767DF06C08e369Dc20F": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00096af89fd96f0d6E1721d9145944e813317d46": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000C5e39879228A1Fc8dF2470822CB8ce2Af8e07": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000ea86B4A3d7e4AF8CFab052c8b9a040149b507": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000796370C839773893a2cEFA5fc81f2332936fB": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000990B05481b1661bc6211298f6429451B09425": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0008a02d3E8507621f430345b98478058cDca79A": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000d35f8cd11bd989216b3669cBaac6fd8c07196": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000541653a96ABAdDba52fAA8D118e570d529543": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0006264bf7E3395309F728222641Ff8D0e1ad2C0": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000688AA0fBfB3F1e6554A63dF13bE08cB671b3b": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00030da862690D170F096074e9E8b38db7D6f037": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0005e37296348571bd3604f7E56B67a7022801f6": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000ed6E0F4Fdc3615663BF4A601E35e7A8d66E1c": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000c53b37fA4977B59FD3Efdb473D8069844aDeA": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00057714949aD700733C5b8E6cF3e8c6B7D228a2": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000C8FC4132881c31f67638c3941dF8D94a92299": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000fA71E446e1EcFd74d835b5bD6fA848A770d26": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000784B47aC2843419Df4cAd697d4e7b65CE1F93": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0002869e27c6FaEe08cCA6b765a726E7a076Ee0F": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0003135C47c441506b58483Ec6173F767182670B": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0006E80d584cbF9EB8C41CF2b009C607744a70F6": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000C1C05dBFf111c79D5c9E91420DFBEA1c31716": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x0009Bf72AF31A4E6B8Ef6FbbFcb017823E4d2aF2": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x00021C20F3e68F930077Cca109Ca3C044E8B39bD": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000E90875aC71eD46A11dc1b509d2B35E2c9C31F": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    },
+    "0x000f17eB09AA3f28132323E6075C672949526d5A": {
+      "balance": "0xc097ce7bc90715b34b9f1000000000"
+    }
+  },
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "difficulty": "0x01",
+  "extraData": "",
+  "gasLimit": "0x17d7840",
+  "nonce": "0x1234",
+  "mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "timestamp": "1718040081"
+}


### PR DESCRIPTION
**Motivation**

This test uses the `test_data/genesis-l2.json` and `test_data/l2-loadtest.rlp` files. The genesis file was changed in #1158, breaking the test because now the genesis block hash changed and so the second block's parent isn't present in the chain anymore. The tests only executed in the CI only whenever a file in `crates/l2/prover/` was touched, leaving the breaking change unnoticed.

**Description**

- bring back the old genesis file as `test_data/genesis-l2-old.json` (a better solution would be to regenerate`test_data/l2-loadtest.rlp`). 
- change the test's CI job to always execute.
