### PR TITLE
chore(core): restore prover CI only triggering on prover changes for now

### DIFF
--- a/.github/workflows/l2_prover_ci.yaml
+++ b/.github/workflows/l2_prover_ci.yaml
@@ -2,8 +2,12 @@ name: L2 Prover CI
 on:
   push:
     branches: ["main"]
+    paths:
+      - "crates/l2/prover/**"
   pull_request:
     branches: ["**"]
+    paths:
+      - "crates/l2/prover/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
**Motivation**

The prover CI is currently broken because of the `c-kzg` dependency now being under the `common` crate, which breaks compilation for the risc0 target. Until we find a solution for that, this PR makes the prover CI only run for prover related PRs

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

